### PR TITLE
[DISQ-29] Use a separate instance of VCFCodec for each partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The following tests all the [GATK 'large' files](https://github.com/broadinstitu
 ```
 mvn verify \
     -Ddisq.test.real.world.files.dir=/home/gatk/src/test/resources/large \
-    -Ddisq.test.real.world.files.ref=/homegatk/src/test/resources/large/human_g1k_v37.20.21.fasta \
+    -Ddisq.test.real.world.files.ref=/home/gatk/src/test/resources/large/human_g1k_v37.20.21.fasta \
     -Ddisq.samtools.bin=/path/to/bin/samtools \
     -Ddisq.bcftools.bin=/path/to/bin/bcftools
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <htsjdk.version>2.16.0</htsjdk.version>
+        <htsjdk.version>2.16.1</htsjdk.version>
         <hadoop.version>2.7.0</hadoop.version>
         <spark.version>2.2.2</spark.version>
     </properties>

--- a/src/main/java/org/disq_bio/disq/impl/formats/bam/HeaderlessBamOutputFormat.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bam/HeaderlessBamOutputFormat.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import org.apache.hadoop.conf.Configuration;
@@ -31,7 +32,7 @@ public class HeaderlessBamOutputFormat extends FileOutputFormat<Void, SAMRecord>
 
     public BamRecordWriter(Configuration conf, Path file, SAMFileHeader header) throws IOException {
       this.out = file.getFileSystem(conf).create(file);
-      BlockCompressedOutputStream compressedOut = new BlockCompressedOutputStream(out, null);
+      BlockCompressedOutputStream compressedOut = new BlockCompressedOutputStream(out, (File) null);
       binaryCodec = new BinaryCodec(compressedOut);
       bamRecordCodec = new BAMRecordCodec(header);
       bamRecordCodec.setOutputStream(compressedOut);

--- a/src/main/java/org/disq_bio/disq/impl/formats/bgzf/BGZFCompressionOutputStream.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bgzf/BGZFCompressionOutputStream.java
@@ -1,6 +1,7 @@
 package org.disq_bio.disq.impl.formats.bgzf;
 
 import htsjdk.samtools.util.BlockCompressedOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
@@ -18,7 +19,7 @@ public class BGZFCompressionOutputStream extends CompressionOutputStream {
 
   public BGZFCompressionOutputStream(OutputStream out) throws IOException {
     super(out);
-    this.output = new BlockCompressedOutputStream(out, null);
+    this.output = new BlockCompressedOutputStream(out, (File) null);
   }
 
   public void write(int b) throws IOException {
@@ -35,7 +36,7 @@ public class BGZFCompressionOutputStream extends CompressionOutputStream {
 
   public void resetState() throws IOException {
     output.flush();
-    output = new BlockCompressedOutputStream(out, null);
+    output = new BlockCompressedOutputStream(out, (File) null);
   }
 
   public void close() throws IOException {

--- a/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfOutputFormat.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfOutputFormat.java
@@ -5,6 +5,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFHeader;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import org.apache.hadoop.conf.Configuration;
@@ -33,7 +34,7 @@ public class VcfOutputFormat extends FileOutputFormat<Void, VariantContext> {
       boolean compressed =
           extension.endsWith(BGZFCodec.DEFAULT_EXTENSION) || extension.endsWith(".gz");
       if (compressed) {
-        out = new BlockCompressedOutputStream(out, null);
+        out = new BlockCompressedOutputStream(out, (File) null);
       }
       variantContextWriter =
           new VariantContextWriterBuilder().clearOptions().setOutputVCFStream(out).build();

--- a/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfSink.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfSink.java
@@ -8,6 +8,7 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFEncoder;
 import htsjdk.variant.vcf.VCFHeader;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
@@ -50,7 +51,8 @@ public class VcfSink extends AbstractVcfSink {
     String headerFile =
         tempPartsDirectory + "/header" + (compressed ? BGZFCodec.DEFAULT_EXTENSION : "");
     try (OutputStream headerOut = fileSystemWrapper.create(jsc.hadoopConfiguration(), headerFile)) {
-      OutputStream out = compressed ? new BlockCompressedOutputStream(headerOut, null) : headerOut;
+      OutputStream out =
+          compressed ? new BlockCompressedOutputStream(headerOut, (File) null) : headerOut;
       VariantContextWriter writer =
           new VariantContextWriterBuilder().clearOptions().setOutputVCFStream(out).build();
       writer.writeHeader(vcfHeader);

--- a/src/test/java/org/disq_bio/disq/BaseTest.java
+++ b/src/test/java/org/disq_bio/disq/BaseTest.java
@@ -20,7 +20,7 @@ public abstract class BaseTest {
   public static void setup() {
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
-    jsc = new JavaSparkContext("local", "myapp", sparkConf);
+    jsc = new JavaSparkContext("local[*]", "myapp", sparkConf);
   }
 
   @AfterClass


### PR DESCRIPTION
This exposes the bug in #29, by using all available cores on a machine for testing (in `BaseTest`). (I was also able to repoduce the bug when [testing on large files](https://github.com/disq-bio/disq#real-world-file-testing).)

The fix relies on the latest htsjdk release.