### PR TITLE
[DISQ-33] Duplicate reads bug

### DIFF
--- a/src/main/java/org/disq_bio/disq/impl/file/PathSplitSource.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/PathSplitSource.java
@@ -3,6 +3,7 @@ package org.disq_bio.disq.impl.file;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
@@ -11,12 +12,15 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.Tuple2;
 
 public class PathSplitSource implements Serializable {
 
   private static final int DEFAULT_NIO_SPLIT_SIZE = 128 * 1024 * 1024;
+  private static final Logger logger = LoggerFactory.getLogger(PathSplitSource.class);
 
   private final FileSystemWrapper fileSystemWrapper;
 
@@ -48,12 +52,14 @@ public class PathSplitSource implements Serializable {
 
       List<Long> range = LongStream.range(0, numSplits).boxed().collect(Collectors.toList());
       return jsc.parallelize(range, numSplits)
-          .map(idx -> idx * actualSplitSize)
-          .flatMap(
-              splitStart -> {
+          .map(
+              idx -> {
+                long splitStart = idx * actualSplitSize;
                 final long splitEnd =
                     splitStart + actualSplitSize > len ? len : splitStart + actualSplitSize;
-                return Collections.singleton(new PathSplit(path, splitStart, splitEnd)).iterator();
+                PathSplit pathSplit = new PathSplit(path, splitStart, splitEnd);
+                logger.debug("PathSplit for partition {}: {}", idx, pathSplit);
+                return pathSplit;
               });
     } else {
       // Use Hadoop FileSystem API to maintain file locality by using Hadoop's FileInputFormat
@@ -64,17 +70,20 @@ public class PathSplitSource implements Serializable {
       }
       return jsc.newAPIHadoopFile(
               path, FileSplitInputFormat.class, Void.class, FileSplit.class, conf)
-          .flatMap(
-              (FlatMapFunction<Tuple2<Void, FileSplit>, PathSplit>)
-                  t2 -> {
+          .mapPartitionsWithIndex(
+              (Function2<Integer, Iterator<Tuple2<Void, FileSplit>>, Iterator<PathSplit>>)
+                  (idx, it) -> {
+                    Tuple2<Void, FileSplit> t2 = it.next(); // one file split per partition
                     FileSplit fileSplit = t2._2();
                     PathSplit pathSplit =
                         new PathSplit(
                             fileSplit.getPath().toString(),
                             fileSplit.getStart(),
                             fileSplit.getStart() + fileSplit.getLength());
+                    logger.debug("PathSplit for partition {}: {}", idx, pathSplit);
                     return Collections.singleton(pathSplit).iterator();
-                  });
+                  },
+              true);
     }
   }
 }

--- a/src/main/java/org/disq_bio/disq/impl/formats/bam/BamSource.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bam/BamSource.java
@@ -134,10 +134,7 @@ public class BamSource extends AbstractBinarySamSource implements Serializable {
             return null;
           }
           long vPos = BlockCompressedFilePointerUtil.makeFilePointer(block.pos, up);
-          // As the guesser goes to the next BGZF block before looking for BAM
-          // records, the ending BGZF blocks have to always be traversed fully.
-          // Hence force the length to be 0xffff, the maximum possible.
-          long vEnd = BlockCompressedFilePointerUtil.makeFilePointer(block.end, 0xffff);
+          long vEnd = BlockCompressedFilePointerUtil.makeFilePointer(block.end); // end is exclusive
           if (bamRecordGuesser.checkRecordStart(vPos)) {
             block.end();
             return new PathChunk(partitionPath, new Chunk(vPos, vEnd));

--- a/src/main/java/org/disq_bio/disq/impl/formats/bgzf/BgzfBlockSource.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bgzf/BgzfBlockSource.java
@@ -67,7 +67,7 @@ public class BgzfBlockSource implements Serializable {
 
       @Override
       protected BgzfBlock advance() {
-        if (start > splitEnd) {
+        if (start >= splitEnd) { // splitEnd is exclusive, so if we reach it then stop
           bgzfBlockGuesser.close();
           return null; // end iteration
         }

--- a/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
@@ -42,7 +42,24 @@ public class HtsjdkReadsRddTest extends BaseTest {
         ReadsFormatWriteOption.BAM,
         0,
         true
-      }
+      },
+      // The split size 76458 was chosen since it is a bgzf block boundary, and it exposes a bug
+      // where reads were included in both splits either side of the boundary. See
+      // BamSourceTest#testPathChunksDontOverlap
+      {
+        "HiSeq.1mb.1RG.2k_lines.alternate.recalibrated.DIQ.sharded.bam/part-r-00000.bam",
+        null,
+        ReadsFormatWriteOption.BAM,
+        76458,
+        false
+      },
+      {
+        "HiSeq.1mb.1RG.2k_lines.alternate.recalibrated.DIQ.sharded.bam/part-r-00000.bam",
+        null,
+        ReadsFormatWriteOption.BAM,
+        76458,
+        false
+      },
     };
   }
 

--- a/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
@@ -58,7 +58,7 @@ public class HtsjdkReadsRddTest extends BaseTest {
         null,
         ReadsFormatWriteOption.BAM,
         76458,
-        false
+        true
       },
     };
   }

--- a/src/test/java/org/disq_bio/disq/impl/formats/bam/BamSourceTest.java
+++ b/src/test/java/org/disq_bio/disq/impl/formats/bam/BamSourceTest.java
@@ -1,0 +1,53 @@
+package org.disq_bio.disq.impl.formats.bam;
+
+import static org.junit.Assert.fail;
+
+import htsjdk.samtools.Chunk;
+import htsjdk.samtools.ValidationStringency;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.disq_bio.disq.BaseTest;
+import org.disq_bio.disq.impl.file.HadoopFileSystemWrapper;
+import org.disq_bio.disq.impl.file.PathChunk;
+import org.disq_bio.disq.impl.formats.bgzf.BgzfBlockGuesser;
+import org.disq_bio.disq.impl.formats.bgzf.BgzfBlockSource;
+import org.junit.Test;
+
+public class BamSourceTest extends BaseTest {
+
+  @Test
+  public void testPathChunksDontOverlap() throws Exception {
+    String inputFile =
+        "HiSeq.1mb.1RG.2k_lines.alternate.recalibrated.DIQ.sharded.bam/part-r-00000.bam";
+
+    HadoopFileSystemWrapper fileSystemWrapper = new HadoopFileSystemWrapper();
+    BgzfBlockSource bgzfBlockSource = new BgzfBlockSource(fileSystemWrapper);
+    List<BgzfBlockGuesser.BgzfBlock> bgzfBlocks =
+        bgzfBlockSource.getBgzfBlocks(jsc, getPath(inputFile), 128 * 1024).collect();
+
+    for (BgzfBlockGuesser.BgzfBlock block : bgzfBlocks) {
+      if (block.pos > 64 * 1024) { // look for blocks bigger than uncompressed BGZF block size
+        int splitSize = (int) block.pos; // try splits that are the BGZF block size
+
+        BamSource bamSource = new BamSource(fileSystemWrapper);
+        List<Chunk> chunks =
+            bamSource
+                .getPathChunks(
+                    jsc, getPath(inputFile), splitSize, ValidationStringency.SILENT, null)
+                .map(PathChunk::getSpan)
+                .collect();
+        chunks = new ArrayList<>(chunks);
+        Collections.sort(chunks);
+        for (int i = 0; i < chunks.size() - 1; i++) {
+          if (chunks.get(i).overlaps(chunks.get(i + 1))) {
+            fail(
+                String.format(
+                    "Overlapping chunks for split size %s: %s and %s (chunks: %s)",
+                    splitSize, chunks.get(i), chunks.get(i + 1), chunks));
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This reproduces the problem (#33) and provides a fix. It also adds log debugging to provide diagnostic information about splits and BGZF chunk boundaries to help with debugging issues like this in the future.

The bug occurs when a BGZF block boundary coincides with a split boundary. Here's a log file for a run using a file that produced an errant count:

```
10:49:42.990 DEBUG BamSource - PathChunk for partition 294: PathChunk{path=file:/home/tom/bamaftersparksortsize.bam, span=9865016001:489-9898557440:65535}
10:49:43.239 DEBUG BamSource - PathChunk for partition 295: PathChunk{path=file:/home/tom/bamaftersparksortsize.bam, span=9898557440:190-9932111872:65535}
```
From the log we see that the spans for the two paths overlap, since the first ends at 9898557440:65535 which is *after* 9898557440:190, where the second starts. This results in duplicate reads in the two partitions. The first span should end at the beginning of the BGZF block where the next span starts, i.e. 9898557440:0.

The problem was observed since 9898557440 is 9440MB, which is a multiple of the default block size, 32MB for local files.  (It is *not* a multiple of the default block size for HDFS, which is 128MB, so the problem was not observed on HDFS unless the split size was set explicitly to 32MB.)





