### PR TITLE
Demonstrate errors reported in issue #27

### DIFF
--- a/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
@@ -108,6 +108,9 @@ public class HtsjdkReadsRddTest extends BaseTest {
 
     HtsjdkReadsRdd htsjdkReadsRdd = htsjdkReadsRddStorage.read(inputPath);
 
+    // reduce to realize the RDD of reads
+    Assert.assertNotNull(htsjdkReadsRdd.getReads().first());
+
     // read the file using htsjdk to get expected number of reads, then count the number in the RDD
     int expectedCount = AnySamTestUtil.countReads(inputPath, refPath);
     Assert.assertEquals(expectedCount, htsjdkReadsRdd.getReads().count());

--- a/src/test/java/org/disq_bio/disq/HtsjdkVariantsRddTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkVariantsRddTest.java
@@ -71,6 +71,9 @@ public class HtsjdkVariantsRddTest extends BaseTest {
 
     HtsjdkVariantsRdd htsjdkVariantsRdd = htsjdkVariantsRddStorage.read(inputPath);
 
+    // reduce to realize the RDD of variants
+    Assert.assertNotNull(htsjdkVariantsRdd.getVariants().first());
+
     // read the file using htsjdk to get expected number of reads, then count the number in the RDD
     int expectedCount = countVariants(inputPath);
     Assert.assertEquals(expectedCount, htsjdkVariantsRdd.getVariants().count());


### PR DESCRIPTION
This pull request will fail to build.  It demonstrates the errors reported in issue #27.

```
$ mvn clean install
...
Tests in error:
  testReadAndWrite(1.bam, null, BAM, 131072, false) [0](org.disq_bio.disq.HtsjdkReadsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.UnsupportedOperationException(..)
  testReadAndWrite(1.bam, null, BAM, 131072, true) [1](org.disq_bio.disq.HtsjdkReadsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.UnsupportedOperationException(..)
  testReadAndWrite(test.sam, null, SAM, 131072, false) [5](org.disq_bio.disq.HtsjdkReadsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.UnsupportedOperationException(..)
  testReadAndWrite(gs://genomics-public-data/NA12878.chr20.sample.bam, null, BAM, 131072, true) [6](org.disq_bio.disq.HtsjdkReadsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.UnsupportedOperationException(..)
  testReadAndWrite(gs://genomics-public-data/NA12878.chr20.sample.bam, null, BAM, 0, true) [7](org.disq_bio.disq.HtsjdkReadsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.UnsupportedOperationException(..)
  testReadAndWrite(HiSeq.1mb.1RG.2k_lines.alternate.recalibrated.DIQ.sharded.bam/part-r-00000.bam, null, BAM, 76458, false) [8](org.disq_bio.disq.HtsjdkReadsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.UnsupportedOperationException(..)
  testReadAndWrite(HiSeq.1mb.1RG.2k_lines.alternate.recalibrated.DIQ.sharded.bam/part-r-00000.bam, null, BAM, 76458, true) [9](org.disq_bio.disq.HtsjdkReadsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.UnsupportedOperationException(..)
  testReadAndWrite(test.vcf, VCF, 131072) [0](org.disq_bio.disq.HtsjdkVariantsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.NullPointerException(..)
  testReadAndWrite(test.vcf, VCF_GZ, 131072) [1](org.disq_bio.disq.HtsjdkVariantsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.NullPointerException(..)
  testReadAndWrite(test.vcf, VCF_BGZ, 131072) [2](org.disq_bio.disq.HtsjdkVariantsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.NullPointerException(..)
  testReadAndWrite(test.vcf.bgz, VCF, 131072) [3](org.disq_bio.disq.HtsjdkVariantsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.NullPointerException(..)
  testReadAndWrite(test.vcf.bgzf.gz, VCF, 131072) [4](org.disq_bio.disq.HtsjdkVariantsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.NullPointerException(..)
  testReadAndWrite(test.vcf.gz, VCF, 131072) [5](org.disq_bio.disq.HtsjdkVariantsRddTest):
Job aborted due to stage failure: Exception while getting task result:
com.esotericsoftware.kryo.KryoException: java.lang.NullPointerException(..)

Tests run: 57, Failures: 0, Errors: 13, Skipped: 1

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```