### PR TITLE
Temporarily disable tests that access public Google cloud storage buckets

### DIFF
--- a/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
@@ -54,20 +54,22 @@ public class HtsjdkReadsRddTest extends BaseTest {
       {"valid.cram", "valid.fasta", ReadsFormatWriteOption.CRAM, 128 * 1024, true},
       {"valid_no_index.cram", "valid.fasta", ReadsFormatWriteOption.CRAM, 128 * 1024, false},
       {"test.sam", null, ReadsFormatWriteOption.SAM, 128 * 1024, false},
-      {
-        "gs://genomics-public-data/NA12878.chr20.sample.bam",
-        null,
-        ReadsFormatWriteOption.BAM,
-        128 * 1024,
-        true
-      },
-      {
-        "gs://genomics-public-data/NA12878.chr20.sample.bam",
-        null,
-        ReadsFormatWriteOption.BAM,
-        0,
-        true
-      },
+      // Disable tests that access public Google cloud storage buckets
+      // while https://github.com/disq-bio/disq/issues/47 is being fixed
+      //      {
+      //        "gs://genomics-public-data/NA12878.chr20.sample.bam",
+      //        null,
+      //        ReadsFormatWriteOption.BAM,
+      //        128 * 1024,
+      //        true
+      //      },
+      //      {
+      //        "gs://genomics-public-data/NA12878.chr20.sample.bam",
+      //        null,
+      //        ReadsFormatWriteOption.BAM,
+      //        0,
+      //        true
+      //      },
       // The split size 76458 was chosen since it is a bgzf block boundary, and it exposes a bug
       // where reads were included in both splits either side of the boundary. See
       // BamSourceTest#testPathChunksDontOverlap


### PR DESCRIPTION
Until #47 is fixed