### PR TITLE
Update Spark dependency version to 2.3.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <htsjdk.version>2.16.1</htsjdk.version>
-        <hadoop.version>2.7.0</hadoop.version>
+        <hadoop.version>2.7.5</hadoop.version>
         <mockito.version>2.22.0</mockito.version>
         <kryo-serializers.version>0.42</kryo-serializers.version>
-        <spark.version>2.2.2</spark.version>
+        <spark.version>2.3.2</spark.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/disq_bio/disq/serializer/DisqKryoRegistrator.java
+++ b/src/main/java/org/disq_bio/disq/serializer/DisqKryoRegistrator.java
@@ -135,6 +135,9 @@ public class DisqKryoRegistrator implements KryoRegistrator {
     // org.disq_bio.disq.impl.formats.bgzf
     kryo.register(org.disq_bio.disq.impl.formats.bgzf.BgzfBlockGuesser.BgzfBlock.class);
 
+    // scala.collection.immutable
+    registerByName(kryo, "scala.collection.immutable.Set$EmptySet$");
+
     // scala.collection.mutable
     kryo.register(scala.collection.mutable.WrappedArray.ofRef.class);
 


### PR DESCRIPTION
This bump to Spark version 2.3.2 feels pretty safe.  We've run into some runtime conflicts between Parquet and Avro dependency versions present in Spark 2.3.2 but I don't believe we'll hit those here.

The bump to Spark 2.4.0 will allow us to provide both Scala 2.11 and Scala 2.12 versions of our dependencies, and given that work towards Spark 3.0 is happening on git head, we should start thinking on how we'll handle cross-building for Spark 2.x and 3.x.

We are set up for cross-building across multiple Scala and Spark versions in ADAM, but it is a bit of a mess, so I'm willing to entertain other forms of build wizardry here.