### PR TITLE
CRAM ReferenceSource is not always broadcastable.

### DIFF
--- a/src/main/java/org/disq_bio/disq/impl/formats/cram/CramReferenceSourceBuilder.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/cram/CramReferenceSourceBuilder.java
@@ -3,7 +3,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2018 Disq contributors
+ * Copyright (c) 2018-2019 Disq contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/disq_bio/disq/impl/formats/cram/CramReferenceSourceBuilder.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/cram/CramReferenceSourceBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Disq
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018 Disq contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.disq_bio.disq.impl.formats.cram;
+
+import htsjdk.samtools.cram.ref.CRAMReferenceSource;
+import htsjdk.samtools.cram.ref.ReferenceSource;
+import htsjdk.samtools.reference.FastaSequenceIndex;
+import htsjdk.samtools.reference.ReferenceSequenceFile;
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.seekablestream.SeekableStream;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.disq_bio.disq.impl.file.FileSystemWrapper;
+
+/** A utility class for creating a {@link CRAMReferenceSource}. */
+public class CramReferenceSourceBuilder {
+  public static CRAMReferenceSource build(
+      FileSystemWrapper fileSystemWrapper, Configuration conf, String referenceSourcePath)
+      throws IOException {
+    SeekableStream refIn = fileSystemWrapper.open(conf, referenceSourcePath);
+    try (SeekableStream indexIn = fileSystemWrapper.open(conf, referenceSourcePath + ".fai")) {
+      FastaSequenceIndex index = new FastaSequenceIndex(indexIn);
+      ReferenceSequenceFile refSeqFile =
+          ReferenceSequenceFileFactory.getReferenceSequenceFile(referenceSourcePath, refIn, index);
+      return new ReferenceSource(refSeqFile);
+    }
+  }
+}

--- a/src/main/java/org/disq_bio/disq/impl/formats/sam/AnySamSinkMultiple.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/sam/AnySamSinkMultiple.java
@@ -27,7 +27,6 @@ package org.disq_bio.disq.impl.formats.sam;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.cram.ref.ReferenceSource;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
@@ -38,7 +37,6 @@ import org.apache.spark.broadcast.Broadcast;
 import org.disq_bio.disq.HtsjdkReadsRdd;
 import org.disq_bio.disq.impl.file.FileSystemWrapper;
 import org.disq_bio.disq.impl.file.HadoopFileSystemWrapper;
-import org.disq_bio.disq.impl.file.NioFileSystemWrapper;
 import org.disq_bio.disq.impl.formats.cram.CramSink;
 import scala.Tuple2;
 
@@ -85,14 +83,7 @@ public class AnySamSinkMultiple extends AbstractSamSink implements Serializable 
             readIterator -> {
               AnySamOutputFormat.setHeader(headerBroadcast.getValue());
               AnySamOutputFormat.setSamFormat(samFormat);
-
-              // Don't broadcast the reference source since it is not always serializable,
-              // even using Kryo (e.g. for GCS)
-              ReferenceSource referenceSource =
-                  referenceSourcePath == null
-                      ? null
-                      : new ReferenceSource(NioFileSystemWrapper.asPath(referenceSourcePath));
-              AnySamOutputFormat.setReferenceSource(referenceSource);
+              AnySamOutputFormat.setReferenceSourcePath(referenceSourcePath);
               return readIterator;
             })
         .mapToPair(


### PR DESCRIPTION
When the CRAM reference is on GCS, writing will fail with a Kryo exception.
This change fixes this by not broadcasting the ReferenceSource.

This is hard to write a unit test for since it needs a GCS bucket to write to, however I have successfully tested it manually.