### PR TITLE
Upgrade to htsjdk 2.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <htsjdk.version>2.18.2</htsjdk.version>
+        <htsjdk.version>2.19.0.rc.1-25-gf9e1fcc-SNAPSHOT</htsjdk.version>
         <hadoop.version>2.7.5</hadoop.version>
         <mockito.version>2.22.0</mockito.version>
         <kryo-serializers.version>0.42</kryo-serializers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <htsjdk.version>2.19.0.rc.1-25-gf9e1fcc-SNAPSHOT</htsjdk.version>
+        <htsjdk.version>2.19.0-rc3-SNAPSHOT</htsjdk.version>
         <hadoop.version>2.7.5</hadoop.version>
         <mockito.version>2.22.0</mockito.version>
         <kryo-serializers.version>0.42</kryo-serializers.version>
@@ -315,6 +315,13 @@
         <url>https://github.com/disq-bio/disq</url>
         <tag>master</tag>
     </scm>
+
+    <repositories>
+        <repository>
+            <id>broad</id>
+            <url>https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/</url>
+        </repository>
+    </repositories>
 
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <htsjdk.version>2.19.0-rc3-SNAPSHOT</htsjdk.version>
+        <htsjdk.version>2.19.0</htsjdk.version>
         <hadoop.version>2.7.5</hadoop.version>
         <mockito.version>2.22.0</mockito.version>
         <kryo-serializers.version>0.42</kryo-serializers.version>
@@ -315,13 +315,6 @@
         <url>https://github.com/disq-bio/disq</url>
         <tag>master</tag>
     </scm>
-
-    <repositories>
-        <repository>
-            <id>broad</id>
-            <url>https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/</url>
-        </repository>
-    </repositories>
 
     <distributionManagement>
         <snapshotRepository>

--- a/src/htsjdk/java/htsjdk/samtools/BAMIndexer2.java
+++ b/src/htsjdk/java/htsjdk/samtools/BAMIndexer2.java
@@ -235,9 +235,7 @@ public class BAMIndexer2 {
 
                 @Override
                 public Integer getIndexingBin() {
-                    final Integer binNumber = rec.getIndexingBin();
-                    return (binNumber == null ? rec.computeIndexingBin() : binNumber);
-
+                    return rec.computeIndexingBin();
                 }
 
                 @Override

--- a/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSource.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSource.java
@@ -152,7 +152,7 @@ public class CramSource extends AbstractBinarySamSource implements Serializable 
       NavigableSet<Long> containerOffsets = new TreeSet<>();
       CRAIIndex index = CRAMCRAIIndexer.readIndex(in);
       for (CRAIEntry entry : index.getCRAIEntries()) {
-        containerOffsets.add(entry.containerStartOffset);
+        containerOffsets.add(entry.getContainerStartByteOffset());
       }
       containerOffsets.add(cramFileLength);
       return containerOffsets;


### PR DESCRIPTION
The changes to CRAM have introduced an incompatible change to CRAIEntry that affects CramSource in Disq. See the note about incompatible CRAM changes
at https://github.com/samtools/htsjdk/releases/tag/2.17.0.

This commit uses the new CRAIEntry API introduced in https://github.com/samtools/htsjdk/pull/1256

Note: the change has not been released yet (so this PR will fail to compile), but a new htsjdk release is imminent, so the Disq 0.2.0 release should wait for it.