### PR TITLE
HTSJDK preview: CRAIEntry fields now need accessors

### DIFF
--- a/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSource.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSource.java
@@ -153,7 +153,7 @@ public class CramSource extends AbstractBinarySamSource implements Serializable 
       NavigableSet<Long> containerOffsets = new TreeSet<>();
       CRAIIndex index = CRAMCRAIIndexer.readIndex(in);
       for (CRAIEntry entry : index.getCRAIEntries()) {
-        containerOffsets.add(entry.containerStartOffset);
+        containerOffsets.add(entry.getContainerStartByteOffset());
       }
       containerOffsets.add(cramFileLength);
       return containerOffsets;


### PR DESCRIPTION
This change will be necessary after updating HTSJDK to the latest version.

I noticed an additional breaking change in the next HTSJDK, but I don't know what the appropriate solution would be: removal of `SAMRecord.getIndexingBin()`.