### PR TITLE
Add a method to FileSystemWrapper to get file lengths when doing a directory listing

### DIFF
--- a/src/main/java/org/disq_bio/disq/impl/file/FileSystemWrapper.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/FileSystemWrapper.java
@@ -43,10 +43,10 @@ public interface FileSystemWrapper extends Serializable {
 
   /** Represents a file in a directory listing. */
   class FileStatus implements Comparable<FileStatus> {
-    private static final Comparator<FileStatus> COMPARATOR = Comparator
-        .comparing(FileStatus::getPath,
-            Comparator.nullsFirst(String::compareToIgnoreCase))
-        .thenComparingLong(FileStatus::getLength);
+    private static final Comparator<FileStatus> COMPARATOR =
+        Comparator.comparing(
+                FileStatus::getPath, Comparator.nullsFirst(String::compareToIgnoreCase))
+            .thenComparingLong(FileStatus::getLength);
 
     private final String path;
     private final long length;

--- a/src/main/java/org/disq_bio/disq/impl/file/FileSystemWrapper.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/FileSystemWrapper.java
@@ -44,8 +44,7 @@ public interface FileSystemWrapper extends Serializable {
   /** Represents a file in a directory listing. */
   class FileStatus implements Comparable<FileStatus> {
     private static final Comparator<FileStatus> COMPARATOR =
-        Comparator.comparing(
-                FileStatus::getPath, Comparator.nullsFirst(String::compareToIgnoreCase))
+        Comparator.comparing(FileStatus::getPath, Comparator.nullsFirst(String::compareTo))
             .thenComparingLong(FileStatus::getLength);
 
     private final String path;

--- a/src/main/java/org/disq_bio/disq/impl/file/FileSystemWrapper.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/FileSystemWrapper.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 
@@ -38,6 +39,49 @@ import org.apache.hadoop.conf.Configuration;
  * filesystem operations.
  */
 public interface FileSystemWrapper extends Serializable {
+
+  /** Represents a file in a directory listing. */
+  class FileStatus implements Comparable<FileStatus> {
+    private final String path;
+    private final long length;
+
+    public FileStatus(String path, long length) {
+      this.path = path;
+      this.length = length;
+    }
+
+    /** @return the file path */
+    public String getPath() {
+      return path;
+    }
+
+    /** @return the length of the file in bytes */
+    public long getLength() {
+      return length;
+    }
+
+    @Override
+    public int compareTo(FileStatus o) {
+      int cmp = path.compareTo(o.path);
+      if (cmp != 0) {
+        return cmp;
+      }
+      return Long.compare(length, o.length);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      FileStatus that = (FileStatus) o;
+      return length == that.length && path.equals(that.path);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(path, length);
+    }
+  }
 
   /** @return true if this implementation uses the {@link java.nio} API */
   boolean usesNio();
@@ -122,6 +166,16 @@ public interface FileSystemWrapper extends Serializable {
    * @throws IOException if an IO error occurs
    */
   List<String> listDirectory(Configuration conf, String path) throws IOException;
+
+  /**
+   * Return the file statuses of files in a directory, in lexicographic order of the paths.
+   *
+   * @param conf the Hadoop configuration
+   * @param path the path to the directory
+   * @return file statuses in lexicographic order of the paths
+   * @throws IOException if an IO error occurs
+   */
+  List<FileStatus> listDirectoryStatus(Configuration conf, String path) throws IOException;
 
   /**
    * Concatenate the contents of multiple files into a single file.

--- a/src/main/java/org/disq_bio/disq/impl/file/FileSystemWrapper.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/FileSystemWrapper.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.seekablestream.SeekableStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -42,6 +43,11 @@ public interface FileSystemWrapper extends Serializable {
 
   /** Represents a file in a directory listing. */
   class FileStatus implements Comparable<FileStatus> {
+    private static final Comparator<FileStatus> COMPARATOR = Comparator
+        .comparing(FileStatus::getPath,
+            Comparator.nullsFirst(String::compareToIgnoreCase))
+        .thenComparingLong(FileStatus::getLength);
+
     private final String path;
     private final long length;
 
@@ -62,11 +68,7 @@ public interface FileSystemWrapper extends Serializable {
 
     @Override
     public int compareTo(FileStatus o) {
-      int cmp = path.compareTo(o.path);
-      if (cmp != 0) {
-        return cmp;
-      }
-      return Long.compare(length, o.length);
+      return COMPARATOR.compare(this, o);
     }
 
     @Override

--- a/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
@@ -113,6 +113,16 @@ public class HadoopFileSystemWrapper implements FileSystemWrapper {
   }
 
   @Override
+  public List<FileStatus> listDirectoryStatus(Configuration conf, String path) throws IOException {
+    Path p = new Path(path);
+    FileSystem fileSystem = p.getFileSystem(conf);
+    return Arrays.stream(fileSystem.listStatus(p))
+        .map(fs -> new FileStatus(fs.getPath().toUri().toString(), fs.getLen()))
+        .sorted()
+        .collect(Collectors.toList());
+  }
+
+  @Override
   public void concat(Configuration conf, List<String> parts, String path) throws IOException {
     // target must be in same directory as parts being concat'ed
     Path tmp = new Path(new Path(parts.get(0)).getParent(), "output");

--- a/src/main/java/org/disq_bio/disq/impl/file/Merger.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/Merger.java
@@ -34,8 +34,19 @@ public class Merger {
 
   private final FileSystemWrapper fileSystemWrapper;
 
-  public Merger() {
-    fileSystemWrapper = new HadoopFileSystemWrapper();
+  public Merger(FileSystemWrapper fileSystemWrapper) {
+    this.fileSystemWrapper = fileSystemWrapper;
+  }
+
+  public void mergeParts(
+      Configuration conf, List<FileSystemWrapper.FileStatus> fileStatuses, String outputFile)
+      throws IOException {
+    List<String> parts =
+        fileStatuses
+            .stream()
+            .map(FileSystemWrapper.FileStatus::getPath)
+            .collect(Collectors.toList());
+    fileSystemWrapper.concat(conf, parts, outputFile);
   }
 
   public void mergeParts(Configuration conf, String tempPartsDirectory, String outputFile)

--- a/src/main/java/org/disq_bio/disq/impl/file/NioFileSystemWrapper.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/NioFileSystemWrapper.java
@@ -100,6 +100,11 @@ public class NioFileSystemWrapper implements FileSystemWrapper {
   }
 
   @Override
+  public List<FileStatus> listDirectoryStatus(Configuration conf, String path) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void concat(Configuration conf, List<String> parts, String path) throws IOException {
     try (OutputStream out = create(conf, path)) {
       for (final String part : parts) {

--- a/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSink.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSink.java
@@ -98,7 +98,7 @@ public class CramSink extends AbstractSamSink {
       CramIO.issueEOF(CramVersions.DEFAULT_CRAM_VERSION, out);
     }
 
-    new Merger().mergeParts(jsc.hadoopConfiguration(), tempPartsDirectory, path);
+    new Merger(fileSystemWrapper).mergeParts(jsc.hadoopConfiguration(), tempPartsDirectory, path);
     fileSystemWrapper.delete(jsc.hadoopConfiguration(), tempPartsDirectory);
   }
 

--- a/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSource.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSource.java
@@ -92,14 +92,15 @@ public class CramSource extends AbstractBinarySamSource implements Serializable 
     // store paths (not full URIs) to avoid differences in scheme - this could be improved
     Map<String, NavigableSet<Long>> pathToContainerOffsets = new LinkedHashMap<>();
     if (fileSystemWrapper.isDirectory(conf, path)) {
-      List<String> paths =
+      List<FileSystemWrapper.FileStatus> statuses =
           fileSystemWrapper
-              .listDirectory(conf, path)
+              .listDirectoryStatus(conf, path)
               .stream()
-              .filter(SamFormat.CRAM::fileMatches)
+              .filter(fs -> SamFormat.CRAM.fileMatches(fs.getPath()))
               .collect(Collectors.toList());
-      for (String p : paths) {
-        long cramFileLength = fileSystemWrapper.getFileLength(conf, p);
+      for (FileSystemWrapper.FileStatus status : statuses) {
+        String p = status.getPath();
+        long cramFileLength = status.getLength();
         NavigableSet<Long> containerOffsets = getContainerOffsetsFromIndex(conf, p, cramFileLength);
         String normPath = URI.create(fileSystemWrapper.normalize(conf, p)).getPath();
         pathToContainerOffsets.put(normPath, containerOffsets);

--- a/src/main/java/org/disq_bio/disq/impl/formats/sam/SamSink.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/sam/SamSink.java
@@ -69,7 +69,7 @@ public class SamSink extends AbstractSamSink {
         new AsciiWriter(fileSystemWrapper.create(jsc.hadoopConfiguration(), headerFile))) {
       new SAMTextHeaderCodec().encode(out, header);
     }
-    new Merger().mergeParts(jsc.hadoopConfiguration(), tempPartsDirectory, path);
+    new Merger(fileSystemWrapper).mergeParts(jsc.hadoopConfiguration(), tempPartsDirectory, path);
     fileSystemWrapper.delete(jsc.hadoopConfiguration(), tempPartsDirectory);
   }
 }

--- a/src/test/java/org/disq_bio/disq/impl/file/MergerTest.java
+++ b/src/test/java/org/disq_bio/disq/impl/file/MergerTest.java
@@ -107,7 +107,8 @@ public class MergerTest {
     Files.write("contents1", file1, Charset.forName("UTF8"));
     Files.write("contents2", file2, Charset.forName("UTF8"));
 
-    new Merger().mergeParts(conf, dir.toURI().toString(), file3.toURI().toString());
+    new Merger(new HadoopFileSystemWrapper())
+        .mergeParts(conf, dir.toURI().toString(), file3.toURI().toString());
 
     Assert.assertEquals("contents1contents2", Files.toString(file3, Charset.forName("UTF8")));
   }
@@ -135,7 +136,7 @@ public class MergerTest {
     cluster.getFileSystem().copyFromLocalFile(new Path(file1.toURI().toString()), hdfsFile1);
     cluster.getFileSystem().copyFromLocalFile(new Path(file2.toURI().toString()), hdfsFile2);
 
-    new Merger()
+    new Merger(new HadoopFileSystemWrapper())
         .mergeParts(
             cluster.getConfiguration(0), hdfsDir.toUri().toString(), hdfsFile3.toUri().toString());
 


### PR DESCRIPTION
This saves many calls to the file system when merging part files. On the local filesystem, and even HDFS, the current behaviour is not noticeable, but when running on GCS with large numbers of files the overhead is significant. (E.g. it took around 1 min to list the file sizes for ~1800 files. With this patch the time was reduced to around 2 seconds.)

Also, pass the current FileSystemWrapper to the Merger, rather than creating a new
instance. (Fixes #65)