### PR TITLE
Merge indexes in a streaming fashion

### DIFF
--- a/src/htsjdk/java/htsjdk/samtools/BAMIndexMerger.java
+++ b/src/htsjdk/java/htsjdk/samtools/BAMIndexMerger.java
@@ -21,7 +21,7 @@ public class BAMIndexMerger implements Closeable {
   private final OutputStream out;
   private final List<Long> partLengths;
   private int numReferences;
-  private List<List<BAMIndexContent>> content;
+  private final List<List<BAMIndexContent>> content = new ArrayList<>();
   private long noCoordinateCount;
 
   public BAMIndexMerger(final OutputStream out, final long headerLength) {
@@ -32,8 +32,7 @@ public class BAMIndexMerger implements Closeable {
 
   public void processIndex(AbstractBAMFileIndex index, long partLength) {
     this.partLengths.add(partLength);
-    if (content == null) {
-      content = new ArrayList<>();
+    if (content.isEmpty()) {
       numReferences = index.getNumberOfReferences();
       for (int ref = 0; ref < numReferences; ref++) {
         content.add(new ArrayList<>());
@@ -52,7 +51,7 @@ public class BAMIndexMerger implements Closeable {
 
   @Override
   public void close() {
-    if (content == null) {
+    if (content.isEmpty()) {
       throw new IllegalArgumentException("Cannot merge zero BAI files");
     }
     long[] offsets = partLengths.stream().mapToLong(i -> i).toArray();

--- a/src/htsjdk/java/htsjdk/samtools/IndexMerger.java
+++ b/src/htsjdk/java/htsjdk/samtools/IndexMerger.java
@@ -1,0 +1,21 @@
+package htsjdk.samtools;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class IndexMerger<T> {
+  protected final OutputStream out;
+  protected final List<Long> partLengths;
+
+  public IndexMerger(final OutputStream out, final long headerLength) {
+    this.out = out;
+    this.partLengths = new ArrayList<>();
+    this.partLengths.add(headerLength);
+  }
+
+  public abstract void processIndex(T index, long partLength);
+
+  public abstract void finish(long dataFileLength) throws IOException;
+}

--- a/src/htsjdk/java/htsjdk/samtools/SBIIndexMerger.java
+++ b/src/htsjdk/java/htsjdk/samtools/SBIIndexMerger.java
@@ -6,7 +6,7 @@ import htsjdk.samtools.util.Log;
 import java.io.OutputStream;
 
 /** Merges SBI files for parts of a file that have been concatenated. */
-public final class SBIIndexMerger {
+public final class SBIIndexMerger extends IndexMerger<SBIIndex> {
 
   private static final Log log = Log.getInstance(SBIIndexMerger.class);
 
@@ -24,6 +24,7 @@ public final class SBIIndexMerger {
    *     an index
    */
   public SBIIndexMerger(final OutputStream out, long headerLength) {
+    super(out, headerLength);
     this.indexWriter = new SBIIndexWriter(out);
     this.offset = headerLength;
   }
@@ -32,7 +33,8 @@ public final class SBIIndexMerger {
    * Add an index for a part of the data file to the merged index. This method should be called for
    * each index for the data file parts, in order.
    */
-  public void processIndex(SBIIndex index) {
+  @Override
+  public void processIndex(SBIIndex index, long partLength) {
     long[] virtualOffsets = index.getVirtualOffsets();
     for (int i = 0; i < virtualOffsets.length - 1; i++) {
       indexWriter.writeVirtualOffset(shiftVirtualFilePointer(virtualOffsets[i], offset));
@@ -65,9 +67,8 @@ public final class SBIIndexMerger {
 
   /**
    * Complete the index, and close the output stream.
-   *
-   * @param dataFileLength the length of the data file in bytes
    */
+  @Override
   public void finish(long dataFileLength) {
     SBIIndex.Header header =
         new SBIIndex.Header(

--- a/src/main/java/org/disq_bio/disq/impl/file/BaiMerger.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/BaiMerger.java
@@ -33,6 +33,11 @@ import htsjdk.samtools.seekablestream.SeekableStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
@@ -67,16 +72,34 @@ public class BaiMerger {
           "Cannot merge different number of BAM and BAI files in " + tempPartsDirectory);
     }
     int i = 0;
+    ExecutorService executorService = Executors.newFixedThreadPool(8);
     try (OutputStream out = fileSystemWrapper.create(conf, outputFile);
         BAMIndexMerger indexMerger = new BAMIndexMerger(out, partLengths.get(i++))) {
-      for (String part : filteredParts) {
-        try (SeekableStream in = fileSystemWrapper.open(conf, part)) {
-          AbstractBAMFileIndex index = BAMIndexMerger.openIndex(in, header.getSequenceDictionary());
-          indexMerger.processIndex(index, partLengths.get(i++));
-        }
-        fileSystemWrapper.delete(conf, part);
+      List<Callable<AbstractBAMFileIndex>> callables =
+          filteredParts
+              .stream()
+              .map(part -> (Callable<AbstractBAMFileIndex>) () -> readIndex(conf, part, header))
+              .collect(Collectors.toList());
+      for (Future<AbstractBAMFileIndex> futureIndex : executorService.invokeAll(callables)) {
+        indexMerger.processIndex(futureIndex.get(), partLengths.get(i++));
       }
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    } catch (ExecutionException e) {
+      throw new IOException(e.getCause());
+    } finally {
+      executorService.shutdown();
     }
     logger.info("Done merging .bai files");
+  }
+
+  private AbstractBAMFileIndex readIndex(Configuration conf, String file, SAMFileHeader header)
+      throws IOException {
+    AbstractBAMFileIndex index;
+    try (SeekableStream in = fileSystemWrapper.open(conf, file)) {
+      index = BAMIndexMerger.openIndex(in, header.getSequenceDictionary());
+    }
+    fileSystemWrapper.delete(conf, file);
+    return index;
   }
 }

--- a/src/main/java/org/disq_bio/disq/impl/file/IndexFileMerger.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/IndexFileMerger.java
@@ -1,0 +1,105 @@
+/*
+ * Disq
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018-2019 Disq contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.disq_bio.disq.impl.file;
+
+import htsjdk.samtools.IndexMerger;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Merges index files for (headerless) parts of a data file into a single index file.
+ *
+ * @param <I> the index type
+ * @param <H> the header type
+ */
+public abstract class IndexFileMerger<I, H> {
+  private static final Logger logger = LoggerFactory.getLogger(IndexFileMerger.class);
+
+  protected final FileSystemWrapper fileSystemWrapper;
+
+  protected IndexFileMerger(FileSystemWrapper fileSystemWrapper) {
+    this.fileSystemWrapper = fileSystemWrapper;
+  }
+
+  protected abstract String getIndexExtension();
+
+  protected abstract IndexMerger<I> newIndexMerger(final OutputStream out, final long headerLength);
+
+  public void mergeParts(
+      Configuration conf,
+      String tempPartsDirectory,
+      String outputFile,
+      H header,
+      List<Long> partLengths,
+      long fileLength)
+      throws IOException {
+    logger.info(
+        "Merging {} files in temp directory {} to {}",
+        getIndexExtension(),
+        tempPartsDirectory,
+        outputFile);
+    List<String> parts = fileSystemWrapper.listDirectory(conf, tempPartsDirectory);
+    List<String> filteredParts =
+        parts.stream().filter(f -> f.endsWith(getIndexExtension())).collect(Collectors.toList());
+    if (partLengths.size() - 2 != filteredParts.size()) { // don't count header and terminator
+      throw new IllegalArgumentException(
+          "Cannot merge different number of BAM and BAI files in " + tempPartsDirectory);
+    }
+    int i = 0;
+    ExecutorService executorService = Executors.newFixedThreadPool(8);
+    try (OutputStream out = fileSystemWrapper.create(conf, outputFile)) {
+      IndexMerger<I> indexMerger = newIndexMerger(out, partLengths.get(i++));
+      List<Callable<I>> callables =
+          filteredParts
+              .stream()
+              .map(part -> (Callable<I>) () -> readIndex(conf, part, header))
+              .collect(Collectors.toList());
+      for (Future<I> futureIndex : executorService.invokeAll(callables)) {
+        indexMerger.processIndex(futureIndex.get(), partLengths.get(i++));
+      }
+      indexMerger.finish(fileLength);
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    } catch (ExecutionException e) {
+      throw new IOException(e.getCause());
+    } finally {
+      executorService.shutdown();
+    }
+    logger.info("Done merging {} files", getIndexExtension());
+  }
+
+  protected abstract I readIndex(Configuration conf, String part, H header) throws IOException;
+}

--- a/src/main/java/org/disq_bio/disq/impl/file/TbiMerger.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/TbiMerger.java
@@ -25,81 +25,41 @@
  */
 package org.disq_bio.disq.impl.file;
 
+import htsjdk.samtools.IndexMerger;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.tribble.index.tabix.TabixIndex;
 import htsjdk.tribble.index.tabix.TabixIndexMerger;
+import htsjdk.variant.vcf.VCFHeader;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.disq_bio.disq.TabixIndexWriteOption;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Merges tabix index files for (headerless) parts of a VCF file into a single index file. */
-public class TbiMerger {
-  private static final Logger logger = LoggerFactory.getLogger(TbiMerger.class);
-
-  private final FileSystemWrapper fileSystemWrapper;
-
+public class TbiMerger extends IndexFileMerger<TabixIndex, VCFHeader> {
   public TbiMerger(FileSystemWrapper fileSystemWrapper) {
-    this.fileSystemWrapper = fileSystemWrapper;
+    super(fileSystemWrapper);
   }
 
-  public void mergeParts(
-      Configuration conf,
-      String tempPartsDirectory,
-      String outputFile,
-      List<Long> partLengths,
-      long fileLength)
+  @Override
+  protected String getIndexExtension() {
+    return TabixIndexWriteOption.getIndexExtension();
+  }
+
+  @Override
+  protected IndexMerger<TabixIndex> newIndexMerger(OutputStream out, long headerLength) {
+    return new TabixIndexMerger(out, headerLength);
+  }
+
+  @Override
+  protected TabixIndex readIndex(Configuration conf, String part, VCFHeader header)
       throws IOException {
-    logger.info("Merging .tbi files in temp directory {} to {}", tempPartsDirectory, outputFile);
-    List<String> parts = fileSystemWrapper.listDirectory(conf, tempPartsDirectory);
-    List<String> filteredParts =
-        parts
-            .stream()
-            .filter(f -> f.endsWith(TabixIndexWriteOption.getIndexExtension()))
-            .collect(Collectors.toList());
-    if (partLengths.size() - 2 != filteredParts.size()) { // don't count header and terminator
-      throw new IllegalArgumentException(
-          "Cannot merge different number of VCF and TBI files in " + tempPartsDirectory);
-    }
-    int i = 0;
-    ExecutorService executorService = Executors.newFixedThreadPool(8);
-    try (OutputStream out = fileSystemWrapper.create(conf, outputFile)) {
-      TabixIndexMerger indexMerger = new TabixIndexMerger(out, partLengths.get(i++));
-      List<Callable<TabixIndex>> callables =
-          filteredParts
-              .stream()
-              .map(part -> (Callable<TabixIndex>) () -> readIndex(conf, part))
-              .collect(Collectors.toList());
-      for (Future<TabixIndex> futureIndex : executorService.invokeAll(callables)) {
-        indexMerger.processIndex(futureIndex.get(), partLengths.get(i++));
-      }
-      indexMerger.finish(fileLength);
-    } catch (InterruptedException e) {
-      throw new IOException(e);
-    } catch (ExecutionException e) {
-      throw new IOException(e.getCause());
-    } finally {
-      executorService.shutdown();
-    }
-    logger.info("Done merging .tbi files");
-  }
-
-  private TabixIndex readIndex(Configuration conf, String file) throws IOException {
     TabixIndex index;
-    try (SeekableStream in = fileSystemWrapper.open(conf, file)) {
+    try (SeekableStream in = fileSystemWrapper.open(conf, part)) {
       index = new TabixIndex(new BlockCompressedInputStream(in));
     }
-    fileSystemWrapper.delete(conf, file);
+    fileSystemWrapper.delete(conf, part);
     return index;
   }
 }

--- a/src/main/java/org/disq_bio/disq/impl/formats/bam/BamSink.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bam/BamSink.java
@@ -99,7 +99,6 @@ public class BamSink extends AbstractSamSink {
     try (OutputStream out = fileSystemWrapper.create(conf, headerFile)) {
       BAMFileWriter.writeHeader(out, header);
     }
-    long headerLength = fileSystemWrapper.getFileLength(conf, headerFile);
 
     String terminatorFile = tempPartsDirectory + "/terminator";
     try (OutputStream out = fileSystemWrapper.create(conf, terminatorFile)) {
@@ -124,12 +123,17 @@ public class BamSink extends AbstractSamSink {
     if (writeSbiFile) {
       new SbiMerger(fileSystemWrapper)
           .mergeParts(
-              conf, tempPartsDirectory, path + SBIIndex.FILE_EXTENSION, headerLength, fileLength);
+              conf, tempPartsDirectory, path + SBIIndex.FILE_EXTENSION, partLengths, fileLength);
     }
     if (writeBaiFile) {
       new BaiMerger(fileSystemWrapper)
           .mergeParts(
-              conf, tempPartsDirectory, path + BAMIndex.BAMIndexSuffix, header, partLengths);
+              conf,
+              tempPartsDirectory,
+              path + BAMIndex.BAMIndexSuffix,
+              header,
+              partLengths,
+              fileLength);
     }
     fileSystemWrapper.delete(conf, tempPartsDirectory);
   }

--- a/src/main/java/org/disq_bio/disq/impl/formats/bam/BamSink.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bam/BamSink.java
@@ -123,7 +123,12 @@ public class BamSink extends AbstractSamSink {
     if (writeSbiFile) {
       new SbiMerger(fileSystemWrapper)
           .mergeParts(
-              conf, tempPartsDirectory, path + SBIIndex.FILE_EXTENSION, partLengths, fileLength);
+              conf,
+              tempPartsDirectory,
+              path + SBIIndex.FILE_EXTENSION,
+              header,
+              partLengths,
+              fileLength);
     }
     if (writeBaiFile) {
       new BaiMerger(fileSystemWrapper)

--- a/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfSink.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfSink.java
@@ -123,6 +123,7 @@ public class VcfSink extends AbstractVcfSink {
               jsc.hadoopConfiguration(),
               tempPartsDirectory,
               path + TabixIndexWriteOption.getIndexExtension(),
+              vcfHeader,
               partLengths,
               fileLength);
     }

--- a/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfSink.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfSink.java
@@ -116,13 +116,15 @@ public class VcfSink extends AbstractVcfSink {
             .collect(Collectors.toList());
 
     new Merger(fileSystemWrapper).mergeParts(jsc.hadoopConfiguration(), vcfParts, path);
+    long fileLength = fileSystemWrapper.getFileLength(jsc.hadoopConfiguration(), path);
     if (writeTbiFile) {
       new TbiMerger(fileSystemWrapper)
           .mergeParts(
               jsc.hadoopConfiguration(),
               tempPartsDirectory,
               path + TabixIndexWriteOption.getIndexExtension(),
-              partLengths);
+              partLengths,
+              fileLength);
     }
 
     fileSystemWrapper.delete(jsc.hadoopConfiguration(), tempPartsDirectory);


### PR DESCRIPTION
When running on cloud storage I observed that it takes a while to merge the index parts (for .bai and .tbi files). The reason is that each part file is read sequentially, which can take a while due to cloud latency. By pipelining the reads the time to merge was reduced from ~10 minutes to ~1 minute (for an exome index).

This PR makes the changes to allow `BAMIndexMerger` and `TabixIndexMerger` to be given a part file one at a time (`SBIIndexMerger` already does this, so the three are being made more consistent). There are also corresponding changes in `BaiMerger` and `TbiMerger`.

