### PR TITLE
Parameterize Scala version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <mockito.version>2.22.0</mockito.version>
         <kryo-serializers.version>0.42</kryo-serializers.version>
         <slf4j.version>1.7.25</slf4j.version>
+        <scala.version>2.11</scala.version>
         <spark.version>2.3.2</spark.version>
     </properties>
 
@@ -93,7 +94,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
+            <artifactId>spark-core_${scala.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>


### PR DESCRIPTION
A small build change to make it easier to test different versions of Spark and Scala. See #66