### PR TITLE
Run read tests on HDFS minicluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M3</version>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
             <classifier>shaded</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.jsr203hadoop</groupId>
+            <artifactId>jsr203hadoop</artifactId>
+            <version>1.0.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/disq_bio/disq/impl/formats/bam/HeaderlessBamOutputFormat.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bam/HeaderlessBamOutputFormat.java
@@ -82,7 +82,7 @@ public class HeaderlessBamOutputFormat extends FileOutputFormat<Void, SAMRecord>
       this.conf = conf;
       this.file = file;
       this.out = file.getFileSystem(conf).create(file);
-      this.compressedOut = new TerminatorlessBlockCompressedOutputStream(out, null);
+      this.compressedOut = new TerminatorlessBlockCompressedOutputStream(out);
       this.binaryCodec = new BinaryCodec(compressedOut);
       this.bamRecordCodec = new BAMRecordCodec(header);
       bamRecordCodec.setOutputStream(compressedOut);

--- a/src/main/java/org/disq_bio/disq/impl/formats/bgzf/BGZFCompressionOutputStream.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bgzf/BGZFCompressionOutputStream.java
@@ -29,7 +29,6 @@ import htsjdk.samtools.util.BlockCompressedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Path;
-
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 
 /**

--- a/src/main/java/org/disq_bio/disq/impl/formats/bgzf/BGZFCompressionOutputStream.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bgzf/BGZFCompressionOutputStream.java
@@ -26,9 +26,10 @@
 package org.disq_bio.disq.impl.formats.bgzf;
 
 import htsjdk.samtools.util.BlockCompressedOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
+
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 
 /**
@@ -44,7 +45,7 @@ public class BGZFCompressionOutputStream extends CompressionOutputStream {
 
   public BGZFCompressionOutputStream(OutputStream out) throws IOException {
     super(out);
-    this.output = new BlockCompressedOutputStream(out, (File) null);
+    this.output = new BlockCompressedOutputStream(out, (Path) null);
   }
 
   public void write(int b) throws IOException {
@@ -61,7 +62,7 @@ public class BGZFCompressionOutputStream extends CompressionOutputStream {
 
   public void resetState() throws IOException {
     output.flush();
-    output = new BlockCompressedOutputStream(out, (File) null);
+    output = new BlockCompressedOutputStream(out, (Path) null);
   }
 
   public void close() throws IOException {

--- a/src/main/java/org/disq_bio/disq/impl/formats/bgzf/TerminatorlessBlockCompressedOutputStream.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bgzf/TerminatorlessBlockCompressedOutputStream.java
@@ -26,9 +26,9 @@
 package org.disq_bio.disq.impl.formats.bgzf;
 
 import htsjdk.samtools.util.BlockCompressedOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
 
 /**
  * An extension of {@link BlockCompressedOutputStream} that doesn't write an empty BGZF block at the
@@ -37,8 +37,8 @@ import java.io.OutputStream;
 public class TerminatorlessBlockCompressedOutputStream extends BlockCompressedOutputStream {
   private final OutputStream out;
 
-  public TerminatorlessBlockCompressedOutputStream(OutputStream os, File file) {
-    super(os, file);
+  public TerminatorlessBlockCompressedOutputStream(OutputStream os) {
+    super(os, (Path) null);
     this.out = os;
   }
 

--- a/src/main/java/org/disq_bio/disq/impl/formats/vcf/HeaderlessVcfOutputFormat.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/vcf/HeaderlessVcfOutputFormat.java
@@ -31,7 +31,6 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.VCFWriterHelper;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import org.apache.hadoop.conf.Configuration;
@@ -75,7 +74,7 @@ public class HeaderlessVcfOutputFormat extends FileOutputFormat<Void, VariantCon
       }
       this.variantContextWriter =
           VCFWriterHelper.buildVCFWriter(
-              blockCompress ? new TerminatorlessBlockCompressedOutputStream(out, (File) null) : out,
+              blockCompress ? new TerminatorlessBlockCompressedOutputStream(out) : out,
               header.getSequenceDictionary(),
               tabixIndexCreator,
               tbiFile != null);

--- a/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfOutputFormat.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfOutputFormat.java
@@ -30,7 +30,6 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import org.apache.hadoop.conf.Configuration;
@@ -59,7 +58,7 @@ public class VcfOutputFormat extends FileOutputFormat<Void, VariantContext> {
       boolean compressed =
           extension.endsWith(BGZFCodec.DEFAULT_EXTENSION) || extension.endsWith(".gz");
       if (compressed) {
-        out = new BlockCompressedOutputStream(out, (File) null);
+        out = new BlockCompressedOutputStream(out, (java.nio.file.Path) null);
       }
       variantContextWriter =
           new VariantContextWriterBuilder().clearOptions().setOutputVCFStream(out).build();

--- a/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfSink.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/vcf/VcfSink.java
@@ -31,9 +31,9 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.spark.api.java.JavaRDD;
@@ -88,7 +88,7 @@ public class VcfSink extends AbstractVcfSink {
         tempPartsDirectory + "/header" + (compressed ? BGZFCodec.DEFAULT_EXTENSION : "");
     try (OutputStream headerOut = fileSystemWrapper.create(jsc.hadoopConfiguration(), headerFile)) {
       OutputStream out =
-          compressed ? new BlockCompressedOutputStream(headerOut, (File) null) : headerOut;
+          compressed ? new BlockCompressedOutputStream(headerOut, (Path) null) : headerOut;
       VariantContextWriter writer =
           new VariantContextWriterBuilder().clearOptions().setOutputVCFStream(out).build();
       writer.writeHeader(vcfHeader);

--- a/src/test/java/org/disq_bio/disq/BaseTest.java
+++ b/src/test/java/org/disq_bio/disq/BaseTest.java
@@ -26,12 +26,13 @@
 package org.disq_bio.disq;
 
 import htsjdk.samtools.SBIIndex;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Arrays;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.spark.SparkConf;
@@ -68,29 +69,24 @@ public abstract class BaseTest {
     return resource.toURI().toString();
   }
 
-  private File createTempFile(String extension) throws IOException {
-    File file = File.createTempFile("test", extension);
-    file.delete();
-    file.deleteOnExit();
-    return file;
-  }
-
   protected String createTempPath(String extension) throws IOException {
-    return createTempFile(extension).toURI().toString();
+    final Path tempFile = Files.createTempFile("test", extension);
+    Files.deleteIfExists(tempFile);
+    tempFile.toFile().deleteOnExit();
+    return tempFile.toUri().toString();
   }
 
-  protected List<String> listPartFiles(String dir) {
-    return Arrays.stream(
-            new File(URI.create(dir)).listFiles(file -> file.getName().startsWith("part-")))
-        .map(f -> f.toURI().toString())
+  protected List<String> listPartFiles(String dir) throws IOException {
+    return Files.list(Paths.get(URI.create(dir)))
+        .filter(path -> path.getFileName().toString().startsWith("part-"))
+        .map(path -> path.toUri().toString())
         .collect(Collectors.toList());
   }
 
-  protected List<String> listSBIIndexFiles(String dir) {
-    return Arrays.stream(
-            new File(URI.create(dir))
-                .listFiles(file -> file.getName().endsWith(SBIIndex.FILE_EXTENSION)))
-        .map(f -> f.toURI().toString())
+  protected List<String> listSBIIndexFiles(String dir) throws IOException {
+    return Files.list(Paths.get(URI.create(dir)))
+        .filter(path -> path.getFileName().toString().endsWith(SBIIndex.FILE_EXTENSION))
+        .map(path -> path.toUri().toString())
         .collect(Collectors.toList());
   }
 }

--- a/src/test/java/org/disq_bio/disq/BcftoolsTestUtil.java
+++ b/src/test/java/org/disq_bio/disq/BcftoolsTestUtil.java
@@ -27,9 +27,12 @@ package org.disq_bio.disq;
 
 import htsjdk.samtools.util.Locatable;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.PumpStreamHandler;
@@ -50,8 +53,8 @@ public class BcftoolsTestUtil {
           BCFTOOLS_BIN_PROPERTY);
       return false;
     }
-    File binFile = new File(bin);
-    if (!binFile.exists()) {
+    Path binFile = Paths.get(bin);
+    if (!Files.exists(binFile)) {
       throw new IllegalArgumentException(
           String.format(
               "%s property is set to non-existent file: %s", BCFTOOLS_BIN_PROPERTY, binFile));
@@ -69,11 +72,11 @@ public class BcftoolsTestUtil {
 
   public static <T extends Locatable> int countVariants(String vcfPath, T interval)
       throws IOException {
-    File vcfFile = new File(URI.create(vcfPath));
+    Path vcfFile = Paths.get(URI.create(vcfPath));
     CommandLine commandLine = new CommandLine(getBcftoolsBin());
     commandLine.addArgument("view");
     commandLine.addArgument("-H"); // no header
-    commandLine.addArgument(vcfFile.getAbsolutePath());
+    commandLine.addArgument(vcfFile.toAbsolutePath().toString());
     if (interval != null) {
       commandLine.addArgument(
           String.format("%s:%s-%s", interval.getContig(), interval.getStart(), interval.getEnd()));

--- a/src/test/java/org/disq_bio/disq/BcftoolsTestUtil.java
+++ b/src/test/java/org/disq_bio/disq/BcftoolsTestUtil.java
@@ -32,7 +32,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.PumpStreamHandler;

--- a/src/test/java/org/disq_bio/disq/HdfsTestUtil.java
+++ b/src/test/java/org/disq_bio/disq/HdfsTestUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Disq
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018-2019 Disq contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.disq_bio.disq;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+
+public class HdfsTestUtil {
+
+  public static MiniDFSCluster startMiniCluster(String testName) throws IOException {
+    File baseDir = new File("./target/hdfs/" + testName).getAbsoluteFile();
+    FileUtil.fullyDelete(baseDir);
+    Configuration conf = new Configuration();
+    conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
+    MiniDFSCluster hdfsCluster = new MiniDFSCluster.Builder(conf).clusterId(testName).build();
+    hdfsCluster.waitActive();
+    return hdfsCluster;
+  }
+}

--- a/src/test/java/org/disq_bio/disq/HtsjdkReadsRddHdfsTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkReadsRddHdfsTest.java
@@ -86,4 +86,9 @@ public class HtsjdkReadsRddHdfsTest extends HtsjdkReadsRddTest {
   protected boolean inputFileMatches(String inputFile) {
     return !inputFile.startsWith("gs://"); // ignore gs: files
   }
+
+  @Override
+  protected boolean runSamtools() {
+    return false; // files aren't local
+  }
 }

--- a/src/test/java/org/disq_bio/disq/HtsjdkReadsRddHdfsTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkReadsRddHdfsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Disq
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018-2019 Disq contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.disq_bio.disq;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import junitparams.JUnitParamsRunner;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class HtsjdkReadsRddHdfsTest extends HtsjdkReadsRddTest {
+
+  private static MiniDFSCluster cluster;
+  private static Path targetBaseDir;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    cluster = HdfsTestUtil.startMiniCluster(HtsjdkReadsRddHdfsTest.class.getName());
+
+    URI clusterURI = cluster.getURI();
+    URI hdfsDir =
+        new URI(
+            clusterURI.getScheme(),
+            null,
+            clusterURI.getHost(),
+            clusterURI.getPort(),
+            "/root",
+            null,
+            null);
+    targetBaseDir = Paths.get(hdfsDir);
+    Files.createDirectories(targetBaseDir);
+    copyLocalResourcesToTargetFilesystem(targetBaseDir);
+  }
+
+  @AfterClass
+  public static void teardownClass() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Override
+  protected String getPath(String pathOrLocalResource) {
+    if (pathOrLocalResource == null) {
+      return null;
+    }
+    // resolve path relative to targetBaseDir base directory
+    Path targetPath = targetBaseDir.resolve(pathOrLocalResource);
+    return targetPath.toUri().toString();
+  }
+
+  @Override
+  protected Path getTempDir() {
+    return targetBaseDir.resolve("/tmp/");
+  }
+
+  @Override
+  protected boolean inputFileMatches(String inputFile) {
+    return !inputFile.startsWith("gs://"); // ignore gs: files
+  }
+}

--- a/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
@@ -56,6 +56,8 @@ public class HtsjdkReadsRddTest extends BaseTest {
     return new Object[][] {
       {"1.bam", null, ReadsFormatWriteOption.BAM, 128 * 1024, false},
       {"1.bam", null, ReadsFormatWriteOption.BAM, 128 * 1024, true},
+      {"1-with-splitting-index.bam", null, ReadsFormatWriteOption.BAM, 128 * 1024, false},
+      {"1-with-splitting-index.bam", null, ReadsFormatWriteOption.BAM, 128 * 1024, true},
       {"valid.cram", "valid.fasta", ReadsFormatWriteOption.CRAM, 128 * 1024, false},
       {"valid.cram", "valid.fasta", ReadsFormatWriteOption.CRAM, 128 * 1024, true},
       {"valid_no_index.cram", "valid.fasta", ReadsFormatWriteOption.CRAM, 128 * 1024, false},
@@ -134,29 +136,6 @@ public class HtsjdkReadsRddTest extends BaseTest {
 
     // check we can read back what we've just written
     Assert.assertEquals(expectedCount, htsjdkReadsRddStorage.read(outputPath).getReads().count());
-  }
-
-  private Object[] parametersForTestReadUsingSBIIndex() {
-    return new Object[][] {
-      {"1-with-splitting-index.bam", 128 * 1024, false},
-      {"1-with-splitting-index.bam", 128 * 1024, true},
-    };
-  }
-
-  @Test
-  @Parameters
-  public void testReadUsingSBIIndex(String inputFile, int splitSize, boolean useNio)
-      throws Exception {
-    String inputPath = getPath(inputFile);
-
-    HtsjdkReadsRddStorage htsjdkReadsRddStorage =
-        HtsjdkReadsRddStorage.makeDefault(jsc).splitSize(splitSize).useNio(useNio);
-
-    HtsjdkReadsRdd htsjdkReadsRdd = htsjdkReadsRddStorage.read(inputPath);
-
-    // read the file using htsjdk to get expected number of reads, then count the number in the RDD
-    int expectedCount = AnySamTestUtil.countReads(inputPath);
-    Assert.assertEquals(expectedCount, htsjdkReadsRdd.getReads().count());
   }
 
   private Object[] parametersForTestWriteSBIIndex() {

--- a/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
@@ -385,7 +385,8 @@ public class HtsjdkReadsRddTest extends BaseTest {
     Assert.assertEquals(expectedCount, htsjdkReadsRdd.getReads().count());
 
     // also check the count with samtools (except for SAM since it cannot do intervals)
-    if (runSamtools() && SamtoolsTestUtil.isSamtoolsAvailable()
+    if (runSamtools()
+        && SamtoolsTestUtil.isSamtoolsAvailable()
         && !formatWriteOption.equals(ReadsFormatWriteOption.SAM)) {
       int expectedCountSamtools =
           SamtoolsTestUtil.countReads(inputPath, refPath, traversalParameters);

--- a/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
@@ -46,13 +46,18 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.disq_bio.disq.impl.formats.sam.SamFormat;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(JUnitParamsRunner.class)
 public class HtsjdkReadsRddTest extends BaseTest {
 
-  private Object[] parametersForTestReadAndWrite() {
+  protected boolean inputFileMatches(String inputFile) {
+    return true;
+  }
+
+  protected Object[] parametersForTestReadAndWrite() {
     return new Object[][] {
       {"1.bam", null, ReadsFormatWriteOption.BAM, 128 * 1024, false},
       {"1.bam", null, ReadsFormatWriteOption.BAM, 128 * 1024, true},
@@ -105,6 +110,9 @@ public class HtsjdkReadsRddTest extends BaseTest {
       int splitSize,
       boolean useNio)
       throws Exception {
+
+    Assume.assumeTrue(inputFileMatches(inputFile));
+
     String inputPath = getPath(inputFile);
     String refPath = getPath(cramReferenceFile);
 

--- a/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
@@ -57,6 +57,10 @@ public class HtsjdkReadsRddTest extends BaseTest {
     return true;
   }
 
+  protected boolean runSamtools() {
+    return true;
+  }
+
   protected Object[] parametersForTestReadAndWrite() {
     return new Object[][] {
       {"1.bam", null, ReadsFormatWriteOption.BAM, 128 * 1024, false},
@@ -138,7 +142,7 @@ public class HtsjdkReadsRddTest extends BaseTest {
 
     // check the new file has the number of expected reads
     Assert.assertEquals(expectedCount, AnySamTestUtil.countReads(outputPath, refPath));
-    if (SamtoolsTestUtil.isSamtoolsAvailable()) {
+    if (runSamtools() && SamtoolsTestUtil.isSamtoolsAvailable()) {
       Assert.assertEquals(expectedCount, SamtoolsTestUtil.countReads(outputPath, refPath));
     }
 
@@ -238,7 +242,7 @@ public class HtsjdkReadsRddTest extends BaseTest {
     // for multiple file, check there are no sbi files
     Assert.assertTrue(listSBIIndexFiles(outputPath).isEmpty());
 
-    if (SamtoolsTestUtil.isSamtoolsAvailable()) {
+    if (runSamtools() && SamtoolsTestUtil.isSamtoolsAvailable()) {
       int totalCountSamtools = 0;
       for (String part : listPartFiles(outputPath)) {
         totalCountSamtools += SamtoolsTestUtil.countReads(part, refPath);
@@ -381,7 +385,7 @@ public class HtsjdkReadsRddTest extends BaseTest {
     Assert.assertEquals(expectedCount, htsjdkReadsRdd.getReads().count());
 
     // also check the count with samtools (except for SAM since it cannot do intervals)
-    if (SamtoolsTestUtil.isSamtoolsAvailable()
+    if (runSamtools() && SamtoolsTestUtil.isSamtoolsAvailable()
         && !formatWriteOption.equals(ReadsFormatWriteOption.SAM)) {
       int expectedCountSamtools =
           SamtoolsTestUtil.countReads(inputPath, refPath, traversalParameters);

--- a/src/test/java/org/disq_bio/disq/SamtoolsTestUtil.java
+++ b/src/test/java/org/disq_bio/disq/SamtoolsTestUtil.java
@@ -27,9 +27,12 @@ package org.disq_bio.disq;
 
 import htsjdk.samtools.util.Locatable;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.PumpStreamHandler;
@@ -50,8 +53,8 @@ public class SamtoolsTestUtil {
           SAMTOOLS_BIN_PROPERTY);
       return false;
     }
-    File binFile = new File(bin);
-    if (!binFile.exists()) {
+    Path binFile = Paths.get(bin);
+    if (!Files.exists(binFile)) {
       throw new IllegalArgumentException(
           String.format(
               "%s property is set to non-existent file: %s", SAMTOOLS_BIN_PROPERTY, binFile));
@@ -75,16 +78,16 @@ public class SamtoolsTestUtil {
       final String samPath, String refPath, HtsjdkReadsTraversalParameters<T> traversalParameters)
       throws IOException {
 
-    final File samFile = new File(URI.create(samPath));
-    final File refFile = refPath == null ? null : new File(URI.create(refPath));
+    final Path samFile = Paths.get(URI.create(samPath));
+    final Path refFile = refPath == null ? null : Paths.get(URI.create(refPath));
     CommandLine commandLine = new CommandLine(getSamtoolsBin());
     commandLine.addArgument("view");
     commandLine.addArgument("-c"); // count
     if (refFile != null) {
       commandLine.addArgument("-T");
-      commandLine.addArgument(refFile.getAbsolutePath());
+      commandLine.addArgument(refFile.toAbsolutePath().toString());
     }
-    commandLine.addArgument(samFile.getAbsolutePath());
+    commandLine.addArgument(samFile.toAbsolutePath().toString());
     if (traversalParameters != null) {
       if (traversalParameters.getIntervalsForTraversal() != null) {
         for (T locatable : traversalParameters.getIntervalsForTraversal()) {

--- a/src/test/java/org/disq_bio/disq/SamtoolsTestUtil.java
+++ b/src/test/java/org/disq_bio/disq/SamtoolsTestUtil.java
@@ -32,7 +32,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.PumpStreamHandler;

--- a/src/test/java/org/disq_bio/disq/impl/file/MergerTest.java
+++ b/src/test/java/org/disq_bio/disq/impl/file/MergerTest.java
@@ -28,14 +28,12 @@ package org.disq_bio.disq.impl.file;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.disq_bio.disq.HdfsTestUtil;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -44,53 +42,17 @@ import org.junit.Test;
 public class MergerTest {
 
   private static MiniDFSCluster cluster;
-  private static URI clusterUri;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    cluster = startMini(MergerTest.class.getName());
-    clusterUri = formalizeClusterURI(cluster.getFileSystem().getUri());
+    cluster = HdfsTestUtil.startMiniCluster(MergerTest.class.getName());
   }
 
   @AfterClass
-  public static void teardownClass() throws Exception {
+  public static void teardownClass() {
     if (cluster != null) {
       cluster.shutdown();
     }
-  }
-
-  private static MiniDFSCluster startMini(String testName) throws IOException {
-    File baseDir = new File("./target/hdfs/" + testName).getAbsoluteFile();
-    FileUtil.fullyDelete(baseDir);
-    Configuration conf = new Configuration();
-    conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
-    MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
-    MiniDFSCluster hdfsCluster = builder.clusterId(testName).build();
-    hdfsCluster.waitActive();
-    return hdfsCluster;
-  }
-
-  protected static URI formalizeClusterURI(URI clusterUri) throws URISyntaxException {
-    if (clusterUri.getPath() == null) {
-      return new URI(
-          clusterUri.getScheme(),
-          null,
-          clusterUri.getHost(),
-          clusterUri.getPort(),
-          "/",
-          null,
-          null);
-    } else if (clusterUri.getPath().trim() == "") {
-      return new URI(
-          clusterUri.getScheme(),
-          null,
-          clusterUri.getHost(),
-          clusterUri.getPort(),
-          "/",
-          null,
-          null);
-    }
-    return clusterUri;
   }
 
   @Test


### PR DESCRIPTION
Currently only the tests in `MergerTest` are run against an HDFS minicluster (as the name suggests, an HDFS cluster that runs in the same JVM, used for testing). This change enables all the tests in `HtsjdkReadsRddTest` to run against HDFS, in addition to the local file system (as they do currently).

To enable this, some refactoring to use `java.nio.file.Path` instead of `java.io.File` was needed.