### PR TITLE
Test large files on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ jdk:
 env:
   - NO_GCE_CHECK=true
 script:
-  - mvn -B test -Ddisq.samtools.bin=/usr/bin/samtools -Ddisq.bcftools.bin=/usr/bin/bcftools
+  - mvn -B verify -Ddisq.test.real.world.files.dir=$TRAVIS_BUILD_DIR/gatk/src/test/resources/large -Ddisq.test.real.world.files.ref=$TRAVIS_BUILD_DIR/gatk/src/test/resources/large/human_g1k_v37.20.21.fasta -Ddisq.samtools.bin=/usr/bin/samtools -Ddisq.bcftools.bin=/usr/bin/bcftools
 cache:
   directories:
     - $HOME/.m2
 before_install:
   - src/build/bin/install-samtools.sh
   - src/build/bin/install-bcftools.sh
+  - src/build/bin/checkout-gatk-large-files.sh

--- a/src/build/bin/checkout-gatk-large-files.sh
+++ b/src/build/bin/checkout-gatk-large-files.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -ex
+git lfs install
+mkdir gatk
+cd gatk
+git init
+git config core.sparseCheckout true
+git remote add -f origin https://github.com/broadinstitute/gatk
+echo "src/test/resources/large/*" > .git/info/sparse-checkout
+git checkout master
+du -sh .

--- a/src/main/java/org/disq_bio/disq/serializer/DisqKryoRegistrator.java
+++ b/src/main/java/org/disq_bio/disq/serializer/DisqKryoRegistrator.java
@@ -134,6 +134,7 @@ public class DisqKryoRegistrator implements KryoRegistrator {
     kryo.register(htsjdk.variant.vcf.VCFHeaderLineCount.class);
     kryo.register(htsjdk.variant.vcf.VCFHeaderLineType.class);
     kryo.register(htsjdk.variant.vcf.VCFInfoHeaderLine.class);
+    kryo.register(htsjdk.variant.vcf.VCFSimpleHeaderLine.class);
 
     // java.io
     kryo.register(java.io.FileDescriptor.class);


### PR DESCRIPTION
This addresses #23 by running `RealWorldFilesIT` against all the GATK large files that are >1MB in size. This includes BAM, CRAM, and VCF.