### PR TITLE
Reduce warning to info on unsuported concat operation.

### DIFF
--- a/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
@@ -137,7 +137,7 @@ public class HadoopFileSystemWrapper implements FileSystemWrapper {
       }
       fileSystem.rename(tmp, target);
     } catch (UnsupportedOperationException e) {
-      logger.warn("Concat not supported, merging serially");
+      logger.info("Concat not supported, merging serially");
       try (OutputStream out = create(conf, path)) {
         for (String part : parts) {
           try (InputStream in = open(conf, part)) {


### PR DESCRIPTION
* Reducing the "Concat not supported, merging serially" message from a warning to an info level statement.
  This message will occur on every run on certain file systems and is generally not a cause for alarm.