### PR TITLE
BAI merge for hg38 fails with OOM

### DIFF
--- a/src/htsjdk/java/htsjdk/samtools/CachingBAMFileIndexOptimized.java
+++ b/src/htsjdk/java/htsjdk/samtools/CachingBAMFileIndexOptimized.java
@@ -1,0 +1,69 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.seekablestream.SeekableStream;
+
+/**
+ * A subclass of CachingBAMFileIndex that is optimized for merging, by returning
+ * null BAMIndexContent objects if all bins are empty.
+ */
+public class CachingBAMFileIndexOptimized extends CachingBAMFileIndex {
+  public CachingBAMFileIndexOptimized(SeekableStream stream, SAMSequenceDictionary dictionary) {
+    super(stream, dictionary);
+  }
+
+  protected BAMIndexContent query(final int referenceSequence, final int startPos, final int endPos) {
+    seek(4);
+
+    final int sequenceCount = readInteger();
+
+    if (referenceSequence >= sequenceCount) {
+      return null;
+    }
+
+    skipToSequence(referenceSequence);
+
+    final int binCount = readInteger();
+
+    if (binCount == 0) {
+      return null;
+    }
+
+    return super.query(referenceSequence, startPos, endPos);
+  }
+
+  private void skipToSequence(final int sequenceIndex) {
+    //Use sequence position cache if available
+    if(sequenceIndexes[sequenceIndex] != -1){
+      seek(sequenceIndexes[sequenceIndex]);
+      return;
+    }
+
+    // Use previous sequence position if in cache
+    final int startSequenceIndex;
+    if (sequenceIndex > 0 && sequenceIndexes[sequenceIndex - 1] != -1) {
+      seek(sequenceIndexes[sequenceIndex - 1]);
+      startSequenceIndex = sequenceIndex - 1;
+    } else {
+      startSequenceIndex = 0;
+    }
+
+    for (int i = startSequenceIndex; i < sequenceIndex; i++) {
+      // System.out.println("# Sequence TID: " + i);
+      final int nBins = readInteger();
+      // System.out.println("# nBins: " + nBins);
+      for (int j = 0; j < nBins; j++) {
+        readInteger(); // bin
+        final int nChunks = readInteger();
+        // System.out.println("# bin[" + j + "] = " + bin + ", nChunks = " + nChunks);
+        skipBytes(16 * nChunks);
+      }
+      final int nLinearBins = readInteger();
+      // System.out.println("# nLinearBins: " + nLinearBins);
+      skipBytes(8 * nLinearBins);
+    }
+
+    //Update sequence position cache
+    sequenceIndexes[sequenceIndex] = position();
+  }
+
+}

--- a/src/test/java/org/disq_bio/disq/BaiMergingTest.java
+++ b/src/test/java/org/disq_bio/disq/BaiMergingTest.java
@@ -86,8 +86,7 @@ public class BaiMergingTest extends BaseTest {
   public void test(String inputFile) throws Exception {
     String inputPath = getPath(inputFile);
 
-    long inputFileLength = new File(inputPath).length();
-    int splitSize = (int) (inputFileLength + 1) / 3; // three part files
+    int splitSize = 64 * 1024; // have a small split size (64K) to test effect of lots of splits
     HtsjdkReadsRddStorage htsjdkReadsRddStorage =
         HtsjdkReadsRddStorage.makeDefault(jsc)
             .splitSize(splitSize)


### PR DESCRIPTION
Merging indexes for a large hg38 BAM file fails with OOM. On the face of it, this is odd since the indexes themselves are all quite small (each well under 1MB), even though there are a lot of them (~1000). However, hg38 has an unusually large number of reference sequences, ~3000 rather than the more usual ~30, and this causes the blowup in memory use.

There are ~3000 ref sequences, and ~1000 parts (and therefore bai files to merge). Calling `AbstractBAMFileIndex#query` creates an array of Bins of size ~4000. The way the bai merging works is that it calls `query` for every reference of every part then combines them at the end. So that's ~10^10 elements stored in memory!

This can be fixed by changing the order of combining. Store all the parts in memory, then combine reference-wise at the end. This only needs to store ~10^6 elements which is a lot more manageable.

The test added in this PR fails with OOM if run alone (i.e. without the other commits). With the fix described above to change the order of combining, the test runs in >4 minutes. There is a further optimization to `CachingBAMFileIndex` that reduces the test time to <1 minute.

Tabix merging suffers from the same problem, so I've fixed that code too. There is no optimization necessary since the index code works in a different way that avoids that particular problem.