### PR TITLE
Use results from SBI index instead of ignoring them

### DIFF
--- a/src/main/java/org/disq_bio/disq/impl/formats/bam/BamSource.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bam/BamSource.java
@@ -120,22 +120,22 @@ public class BamSource extends AbstractBinarySamSource implements Serializable {
     } else {
       logger.debug("Using guessing for finding splits");
       SerializableHadoopConfiguration confSer =
-              new SerializableHadoopConfiguration(jsc.hadoopConfiguration());
+          new SerializableHadoopConfiguration(jsc.hadoopConfiguration());
       return bgzfBlockSource
-              .getBgzfBlocks(jsc, path, splitSize)
-              .mapPartitionsWithIndex(
-                      (Function2<Integer, Iterator<BgzfBlockGuesser.BgzfBlock>, Iterator<PathChunk>>)
-                              (partitionIndex, bgzfBlocks) -> {
-                                Configuration conf = confSer.getConf();
-                                PathChunk pathChunk =
-                                        getFirstReadInPartition(conf, bgzfBlocks, stringency, referenceSourcePath);
-                                logger.debug("PathChunk for partition {}: {}", partitionIndex, pathChunk);
-                                if (pathChunk == null) {
-                                  return Collections.emptyIterator();
-                                }
-                                return Collections.singleton(pathChunk).iterator();
-                              },
-                      true);
+          .getBgzfBlocks(jsc, path, splitSize)
+          .mapPartitionsWithIndex(
+              (Function2<Integer, Iterator<BgzfBlockGuesser.BgzfBlock>, Iterator<PathChunk>>)
+                  (partitionIndex, bgzfBlocks) -> {
+                    Configuration conf = confSer.getConf();
+                    PathChunk pathChunk =
+                        getFirstReadInPartition(conf, bgzfBlocks, stringency, referenceSourcePath);
+                    logger.debug("PathChunk for partition {}: {}", partitionIndex, pathChunk);
+                    if (pathChunk == null) {
+                      return Collections.emptyIterator();
+                    }
+                    return Collections.singleton(pathChunk).iterator();
+                  },
+              true);
     }
   }
 

--- a/src/main/java/org/disq_bio/disq/impl/formats/bam/BamSource.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/bam/BamSource.java
@@ -102,7 +102,7 @@ public class BamSource extends AbstractBinarySamSource implements Serializable {
       try (SeekableStream sbiStream = fileSystemWrapper.open(jsc.hadoopConfiguration(), sbiPath)) {
         SBIIndex sbiIndex = SBIIndex.load(sbiStream);
         Broadcast<SBIIndex> sbiIndexBroadcast = jsc.broadcast(sbiIndex);
-        pathSplitSource
+        return pathSplitSource
             .getPathSplits(jsc, path, splitSize)
             .flatMap(
                 pathSplit -> {
@@ -117,26 +117,26 @@ public class BamSource extends AbstractBinarySamSource implements Serializable {
                   }
                 });
       }
+    } else {
+      logger.debug("Using guessing for finding splits");
+      SerializableHadoopConfiguration confSer =
+              new SerializableHadoopConfiguration(jsc.hadoopConfiguration());
+      return bgzfBlockSource
+              .getBgzfBlocks(jsc, path, splitSize)
+              .mapPartitionsWithIndex(
+                      (Function2<Integer, Iterator<BgzfBlockGuesser.BgzfBlock>, Iterator<PathChunk>>)
+                              (partitionIndex, bgzfBlocks) -> {
+                                Configuration conf = confSer.getConf();
+                                PathChunk pathChunk =
+                                        getFirstReadInPartition(conf, bgzfBlocks, stringency, referenceSourcePath);
+                                logger.debug("PathChunk for partition {}: {}", partitionIndex, pathChunk);
+                                if (pathChunk == null) {
+                                  return Collections.emptyIterator();
+                                }
+                                return Collections.singleton(pathChunk).iterator();
+                              },
+                      true);
     }
-
-    logger.debug("Using guessing for finding splits");
-    SerializableHadoopConfiguration confSer =
-        new SerializableHadoopConfiguration(jsc.hadoopConfiguration());
-    return bgzfBlockSource
-        .getBgzfBlocks(jsc, path, splitSize)
-        .mapPartitionsWithIndex(
-            (Function2<Integer, Iterator<BgzfBlockGuesser.BgzfBlock>, Iterator<PathChunk>>)
-                (partitionIndex, bgzfBlocks) -> {
-                  Configuration conf = confSer.getConf();
-                  PathChunk pathChunk =
-                      getFirstReadInPartition(conf, bgzfBlocks, stringency, referenceSourcePath);
-                  logger.debug("PathChunk for partition {}: {}", partitionIndex, pathChunk);
-                  if (pathChunk == null) {
-                    return Collections.emptyIterator();
-                  }
-                  return Collections.singleton(pathChunk).iterator();
-                },
-            true);
   }
 
   /**


### PR DESCRIPTION
* We were querying the SBI index, throwing those results away, and then split-guessing.
* Now the sbi results are used if they are available.
* Fixes https://github.com/disq-bio/disq/issues/123

@wangdy12 I believe this fixes the problem.  I'm shocked we never noticed that before, but I guess I always run with verbosity higher than debug.