### PR TITLE
Update for htsjdk CRAM changes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.source>${java.version}</maven.compiler.source>
-        <htsjdk.version>2.22.0_rc1-SNAPSHOT</htsjdk.version>
+        <htsjdk.version>2.22.0_rc2-SNAPSHOT</htsjdk.version>
         <hadoop.version>2.7.5</hadoop.version>
         <mockito.version>2.22.0</mockito.version>
         <kryo-serializers.version>0.42</kryo-serializers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.source>${java.version}</maven.compiler.source>
-        <htsjdk.version>2.21.1</htsjdk.version>
+        <htsjdk.version>2.22.0_rc1-SNAPSHOT</htsjdk.version>
         <hadoop.version>2.7.5</hadoop.version>
         <mockito.version>2.22.0</mockito.version>
         <kryo-serializers.version>0.42</kryo-serializers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.source>${java.version}</maven.compiler.source>
-        <htsjdk.version>2.22.0_rc2-SNAPSHOT</htsjdk.version>
+        <htsjdk.version>2.22.0</htsjdk.version>
         <hadoop.version>2.7.5</hadoop.version>
         <mockito.version>2.22.0</mockito.version>
         <kryo-serializers.version>0.42</kryo-serializers.version>

--- a/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSink.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSink.java
@@ -100,7 +100,7 @@ public class CramSink extends AbstractSamSink {
 
     String terminatorFile = tempPartsDirectory + "/terminator";
     try (OutputStream out = fileSystemWrapper.create(conf, terminatorFile)) {
-      CramIO.issueEOF(CramVersions.DEFAULT_CRAM_VERSION, out);
+      CramIO.writeCRAMEOF(CramVersions.DEFAULT_CRAM_VERSION, out);
     }
 
     List<FileSystemWrapper.FileStatus> cramParts =

--- a/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSink.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSink.java
@@ -100,7 +100,7 @@ public class CramSink extends AbstractSamSink {
 
     String terminatorFile = tempPartsDirectory + "/terminator";
     try (OutputStream out = fileSystemWrapper.create(conf, terminatorFile)) {
-      CramIO.writeCRAMEOF(CramVersions.DEFAULT_CRAM_VERSION, out);
+      CramIO.writeCramEOF(CramVersions.DEFAULT_CRAM_VERSION, out);
     }
 
     List<FileSystemWrapper.FileStatus> cramParts =

--- a/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSource.java
+++ b/src/main/java/org/disq_bio/disq/impl/formats/cram/CramSource.java
@@ -166,7 +166,7 @@ public class CramSource extends AbstractBinarySamSource implements Serializable 
       NavigableSet<Long> containerOffsets = new TreeSet<>();
       while (it.hasNext()) {
         Container container = it.next();
-        containerOffsets.add(container.byteOffset);
+        containerOffsets.add(container.getContainerByteOffset());
       }
       containerOffsets.add(cramFileLength);
       return containerOffsets;


### PR DESCRIPTION
These changes depend on, and will be required for the next release of htsjdk, which will have some CRAM changes.