### PR TITLE
Fixing RealWorldFilesIT (#132)

### DIFF
--- a/src/test/java/org/disq_bio/disq/BcftoolsTestUtil.java
+++ b/src/test/java/org/disq_bio/disq/BcftoolsTestUtil.java
@@ -103,8 +103,8 @@ public class BcftoolsTestUtil {
               "Bcftools produced stderr while processing file %s. Stderr: %s", vcfFile, error));
     }
     final String[] lines = result.split("\r\n|\r|\n");
-    if( lines.length == 1 && lines[0].isEmpty()){
-      return 0;   
+    if (lines.length == 1 && lines[0].isEmpty()) {
+      return 0;
     }
     return lines.length;
   }

--- a/src/test/java/org/disq_bio/disq/BcftoolsTestUtil.java
+++ b/src/test/java/org/disq_bio/disq/BcftoolsTestUtil.java
@@ -102,6 +102,10 @@ public class BcftoolsTestUtil {
           String.format(
               "Bcftools produced stderr while processing file %s. Stderr: %s", vcfFile, error));
     }
-    return result.split("\r\n|\r|\n").length;
+    final String[] lines = result.split("\r\n|\r|\n");
+    if( lines.length == 1 && lines[0].isEmpty()){
+      return 0;   
+    }
+    return lines.length;
   }
 }

--- a/src/test/java/org/disq_bio/disq/BcftoolsTestUtilTest.java
+++ b/src/test/java/org/disq_bio/disq/BcftoolsTestUtilTest.java
@@ -1,0 +1,30 @@
+package org.disq_bio.disq;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+@RunWith(JUnitParamsRunner.class)
+public class BcftoolsTestUtilTest extends BaseTest {
+
+    private Object[] parametersForTestBcfToolsCountVariants(){
+        return new Object[][]{
+                {"test.vcf", 5},
+                {"testEmpty.vcf", 0}
+        };
+    }
+
+    @Test
+    @Parameters
+    public void testBcfToolsCountVariants(String vcfPath, int expected) throws IOException, URISyntaxException {
+        Assume.assumeTrue(BcftoolsTestUtil.isBcftoolsAvailable());
+        Assert.assertEquals(expected, BcftoolsTestUtil.countVariants(getPath(vcfPath)));
+    }
+}

--- a/src/test/java/org/disq_bio/disq/BcftoolsTestUtilTest.java
+++ b/src/test/java/org/disq_bio/disq/BcftoolsTestUtilTest.java
@@ -25,6 +25,8 @@
  */
 package org.disq_bio.disq;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Assert;
@@ -32,24 +34,21 @@ import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-
 @RunWith(JUnitParamsRunner.class)
 public class BcftoolsTestUtilTest extends BaseTest {
 
-    private Object[] parametersForTestBcfToolsCountVariants(){
-        return new Object[][]{
-                {"test.vcf", 5},
-                {"testEmpty.vcf", 0}
-        };
-    }
+  private Object[] parametersForTestBcfToolsCountVariants() {
+    return new Object[][] {
+      {"test.vcf", 5},
+      {"testEmpty.vcf", 0}
+    };
+  }
 
-    @Test
-    @Parameters
-    public void testBcfToolsCountVariants(String vcfPath, int expected) throws IOException, URISyntaxException {
-        Assume.assumeTrue(BcftoolsTestUtil.isBcftoolsAvailable());
-        Assert.assertEquals(expected, BcftoolsTestUtil.countVariants(getPath(vcfPath)));
-    }
+  @Test
+  @Parameters
+  public void testBcfToolsCountVariants(String vcfPath, int expected)
+      throws IOException, URISyntaxException {
+    Assume.assumeTrue(BcftoolsTestUtil.isBcftoolsAvailable());
+    Assert.assertEquals(expected, BcftoolsTestUtil.countVariants(getPath(vcfPath)));
+  }
 }

--- a/src/test/java/org/disq_bio/disq/BcftoolsTestUtilTest.java
+++ b/src/test/java/org/disq_bio/disq/BcftoolsTestUtilTest.java
@@ -1,3 +1,28 @@
+/*
+ * Disq
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018-2019 Disq contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.disq_bio.disq;
 
 import junitparams.JUnitParamsRunner;

--- a/src/test/resources/testEmpty.vcf
+++ b/src/test/resources/testEmpty.vcf
@@ -1,0 +1,19 @@
+##fileformat=VCFv4.1
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
+##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>
+##phasing=partial
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003


### PR DESCRIPTION
* Fixes https://github.com/disq-bio/disq/issues/132
* There was a bug in BcftoolsTestUtil which counted empty vcfs as having 1 record.
  An empty vcf was added to the GATK test files which we test against which then caused our tests to fail.
  This fixes the problem by correctly counting empty vcfs as having 0 records when testing with Bcftools.