### PR TITLE
Fix shard ordering bug on some filesystems.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.disq-bio</groupId>
     <artifactId>disq</artifactId>
-    <version>0.3.7-SNAPSHOT</version>
+    <version>0.3.7-bugfix-SNAPSHOT</version>
     <name>Disq</name>
     <description>A library for manipulating bioinformatics sequencing formats in Apache Spark.</description>
     <url>https://github.com/disq-bio/disq</url>


### PR DESCRIPTION
* We were relying on the results of FileInputFormat.listStatus() returning a sorted set of statuses when loading multiple parts files.
  This is not a safe assumption on some files systems which return them in essentially random order.
  This corrects the problem by overriding listStatus in FileSplitInputFormat and sorting the results.
* See https://github.com/broadinstitute/gatk/issues/5881 for additional information.