### PR TITLE
Updating to spark 3.0.1 and hadoop 3.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 matrix:
   include:
     - jdk: openjdk8
-      env: JAVA_RELEASE=8 JAVA_VERSION=1.8 SCALA_VERSION=2.11
+      env: JAVA_RELEASE=8 JAVA_VERSION=1.8 SCALA_VERSION=2.12
     - jdk: openjdk11
       env: JAVA_RELEASE=11 JAVA_VERSION=11 SCALA_VERSION=2.12
 env:

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <kryo-serializers.version>0.42</kryo-serializers.version>
         <slf4j.version>1.7.30</slf4j.version>
         <scala.version>2.12</scala.version>
-        <spark.version>3.0.0</spark.version>
+        <spark.version>3.0.1</spark.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,12 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <htsjdk.version>2.22.0</htsjdk.version>
-        <hadoop.version>2.7.5</hadoop.version>
+        <hadoop.version>3.2.1</hadoop.version>
         <mockito.version>2.22.0</mockito.version>
         <kryo-serializers.version>0.42</kryo-serializers.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <scala.version>2.11</scala.version>
-        <spark.version>2.4.6</spark.version>
+        <scala.version>2.12</scala.version>
+        <spark.version>3.0.0</spark.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
@@ -60,10 +60,11 @@ public class HadoopFileSystemWrapper implements FileSystemWrapper {
     return fileSystem.makeQualified(p).toString();
   }
 
-  private static FileSystem getFileSystem(final Configuration conf, final Path p) throws IOException {
+  private static FileSystem getFileSystem(final Configuration conf, final Path p)
+      throws IOException {
     final FileSystem fileSystem = p.getFileSystem(conf);
     if (fileSystem instanceof LocalFileSystem) {
-      return ((LocalFileSystem)fileSystem).getRawFileSystem();
+      return ((LocalFileSystem) fileSystem).getRawFileSystem();
     } else {
       return fileSystem;
     }

--- a/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
@@ -63,10 +63,11 @@ public class HadoopFileSystemWrapper implements FileSystemWrapper {
   private static FileSystem getFileSystem(final Configuration conf, final Path p)
       throws IOException {
     final FileSystem fileSystem = p.getFileSystem(conf);
-    // This replacement of the local filesystem with the raw local filesystem is necessary to avoid checksum errors
-    // from the wrapper of the raw file system which computes checksums.
-    // This is a workaround for an empirical problem and ideally could be removed if we could understand the source
-    // of the check sum errors better.
+
+    // This replacement of the local filesystem with the raw local filesystem is necessary to avoid
+    // checksum errors from the wrapper of the raw file system which computes checksums.
+    // This is a workaround for an empirical problem and ideally could be removed if we could
+    // understand the cause of the check sum errors better.
     if (fileSystem instanceof LocalFileSystem) {
       return ((LocalFileSystem) fileSystem).getRawFileSystem();
     } else {

--- a/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.io.IOUtils;
@@ -55,14 +56,23 @@ public class HadoopFileSystemWrapper implements FileSystemWrapper {
   @Override
   public String normalize(Configuration conf, String path) throws IOException {
     Path p = new Path(path);
-    FileSystem fileSystem = p.getFileSystem(conf);
+    FileSystem fileSystem = getFileSystem(conf, p);
     return fileSystem.makeQualified(p).toString();
+  }
+
+  private static FileSystem getFileSystem(final Configuration conf, final Path p) throws IOException {
+    final FileSystem fileSystem = p.getFileSystem(conf);
+    if (fileSystem instanceof LocalFileSystem) {
+      return ((LocalFileSystem)fileSystem).getRawFileSystem();
+    } else {
+      return fileSystem;
+    }
   }
 
   @Override
   public SeekableStream open(Configuration conf, String path) throws IOException {
     Path p = new Path(path);
-    FileSystem fileSystem = p.getFileSystem(conf);
+    FileSystem fileSystem = getFileSystem(conf, p);
     long len = fileSystem.getFileStatus(p).getLen();
     return new SeekableBufferedStream(new SeekableHadoopStream<>(fileSystem.open(p), len, path));
   }
@@ -70,42 +80,42 @@ public class HadoopFileSystemWrapper implements FileSystemWrapper {
   @Override
   public OutputStream create(Configuration conf, String path) throws IOException {
     Path p = new Path(path);
-    FileSystem fileSystem = p.getFileSystem(conf);
+    FileSystem fileSystem = getFileSystem(conf, p);
     return fileSystem.create(p);
   }
 
   @Override
   public boolean delete(Configuration conf, String path) throws IOException {
     Path p = new Path(path);
-    FileSystem fileSystem = p.getFileSystem(conf);
+    FileSystem fileSystem = getFileSystem(conf, p);
     return fileSystem.delete(p, true);
   }
 
   @Override
   public boolean exists(Configuration conf, String path) throws IOException {
     Path p = new Path(path);
-    FileSystem fileSystem = p.getFileSystem(conf);
+    FileSystem fileSystem = getFileSystem(conf, p);
     return fileSystem.exists(p);
   }
 
   @Override
   public long getFileLength(Configuration conf, String path) throws IOException {
     Path p = new Path(path);
-    FileSystem fileSystem = p.getFileSystem(conf);
+    FileSystem fileSystem = getFileSystem(conf, p);
     return fileSystem.getFileStatus(p).getLen();
   }
 
   @Override
   public boolean isDirectory(Configuration conf, String path) throws IOException {
     Path p = new Path(path);
-    FileSystem fileSystem = p.getFileSystem(conf);
-    return fileSystem.isDirectory(p);
+    FileSystem fileSystem = getFileSystem(conf, p);
+    return fileSystem.getFileStatus(p).isDirectory();
   }
 
   @Override
   public List<String> listDirectory(Configuration conf, String path) throws IOException {
     Path p = new Path(path);
-    FileSystem fileSystem = p.getFileSystem(conf);
+    FileSystem fileSystem = getFileSystem(conf, p);
     return Arrays.stream(fileSystem.listStatus(p))
         .map(fs -> fs.getPath().toUri().toString())
         .sorted()
@@ -115,7 +125,7 @@ public class HadoopFileSystemWrapper implements FileSystemWrapper {
   @Override
   public List<FileStatus> listDirectoryStatus(Configuration conf, String path) throws IOException {
     Path p = new Path(path);
-    FileSystem fileSystem = p.getFileSystem(conf);
+    FileSystem fileSystem = getFileSystem(conf, p);
     return Arrays.stream(fileSystem.listStatus(p))
         .map(fs -> new FileStatus(fs.getPath().toUri().toString(), fs.getLen()))
         .sorted()
@@ -126,7 +136,7 @@ public class HadoopFileSystemWrapper implements FileSystemWrapper {
   public void concat(Configuration conf, List<String> parts, String path) throws IOException {
     // target must be in same directory as parts being concat'ed
     Path tmp = new Path(new Path(parts.get(0)).getParent(), "output");
-    FileSystem fileSystem = tmp.getFileSystem(conf);
+    FileSystem fileSystem = getFileSystem(conf, tmp);
     fileSystem.create(tmp).close(); // target must already exist for concat
     try {
       logger.info("Concatenating {} parts to {}", parts.size(), path);

--- a/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
+++ b/src/main/java/org/disq_bio/disq/impl/file/HadoopFileSystemWrapper.java
@@ -63,6 +63,10 @@ public class HadoopFileSystemWrapper implements FileSystemWrapper {
   private static FileSystem getFileSystem(final Configuration conf, final Path p)
       throws IOException {
     final FileSystem fileSystem = p.getFileSystem(conf);
+    // This replacement of the local filesystem with the raw local filesystem is necessary to avoid checksum errors
+    // from the wrapper of the raw file system which computes checksums.
+    // This is a workaround for an empirical problem and ideally could be removed if we could understand the source
+    // of the check sum errors better.
     if (fileSystem instanceof LocalFileSystem) {
       return ((LocalFileSystem) fileSystem).getRawFileSystem();
     } else {

--- a/src/test/java/org/disq_bio/disq/BaseTest.java
+++ b/src/test/java/org/disq_bio/disq/BaseTest.java
@@ -53,7 +53,7 @@ public abstract class BaseTest {
   public static void setup() {
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
-    sparkConf.set("spark.driver.bindAddress", "127.0.0.1"); 
+    sparkConf.set("spark.driver.bindAddress", "127.0.0.1");
     sparkConf.set("spark.kryo.registrator", "org.disq_bio.disq.serializer.DisqKryoRegistrator");
     sparkConf.set("spark.kryo.referenceTracking", "true");
     sparkConf.set("spark.kryo.registrationRequired", "true");

--- a/src/test/java/org/disq_bio/disq/BaseTest.java
+++ b/src/test/java/org/disq_bio/disq/BaseTest.java
@@ -53,6 +53,7 @@ public abstract class BaseTest {
   public static void setup() {
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
+    sparkConf.set("spark.driver.bindAddress", "127.0.0.1"); 
     sparkConf.set("spark.kryo.registrator", "org.disq_bio.disq.serializer.DisqKryoRegistrator");
     sparkConf.set("spark.kryo.referenceTracking", "true");
     sparkConf.set("spark.kryo.registrationRequired", "true");

--- a/src/test/java/org/disq_bio/disq/impl/file/MergerTest.java
+++ b/src/test/java/org/disq_bio/disq/impl/file/MergerTest.java
@@ -29,6 +29,7 @@ import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import org.apache.commons.codec.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -103,6 +104,7 @@ public class MergerTest {
             cluster.getConfiguration(0), hdfsDir.toUri().toString(), hdfsFile3.toUri().toString());
 
     Assert.assertEquals(
-        "contents1contents2", IOUtils.toString(cluster.getFileSystem().open(hdfsFile3)));
+        "contents1contents2",
+        IOUtils.toString(cluster.getFileSystem().open(hdfsFile3), Charsets.UTF_8));
   }
 }


### PR DESCRIPTION
Fixes #130, fixes #142 

@heuermh Can you weigh in on this?  I needed to make a weird change to use the RawLocalFileSystem in order to avoid a checksum issue.   I'm not sure why we're getting the checksum failure though.  I suspect it's not getting recomputed correctly after some operation but I don't know why.

If I don't force it to use the raw filesystem we get 
```
htsjdk.samtools.util.RuntimeIOException: org.apache.hadoop.fs.ChecksumException: Checksum error: file:/var/folders/q3/hw5cxmn52wq347lg7rb_mzlw0000gq/T/test1179670579977857255.vcf at 0

	at htsjdk.tribble.readers.AsciiLineReaderIterator$TupleIterator.advance(AsciiLineReaderIterator.java:88)
	at htsjdk.tribble.readers.AsciiLineReaderIterator$TupleIterator.advance(AsciiLineReaderIterator.java:75)
	at htsjdk.samtools.util.AbstractIterator.hasNext(AbstractIterator.java:44)
	at htsjdk.tribble.readers.AsciiLineReaderIterator$TupleIterator.<init>(AsciiLineReaderIterator.java:78)
	at htsjdk.tribble.readers.AsciiLineReaderIterator.<init>(AsciiLineReaderIterator.java:33)
	at org.disq_bio.disq.impl.formats.vcf.VcfSource.getFileHeader(VcfSource.java:80)
	at org.disq_bio.disq.HtsjdkVariantsRddStorage.read(HtsjdkVariantsRddStorage.java:96)
	at org.disq_bio.disq.HtsjdkVariantsRddStorage.read(HtsjdkVariantsRddStorage.java:80)
	at org.disq_bio.disq.HtsjdkVariantsRddTest.testReadAndWrite(HtsjdkVariantsRddTest.java:97)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at junitparams.internal.InvokeParameterisedMethod.evaluate(InvokeParameterisedMethod.java:234)
	at junitparams.internal.ParameterisedTestMethodRunner.runMethodInvoker(ParameterisedTestMethodRunner.java:47)
	at junitparams.internal.ParameterisedTestMethodRunner.runTestMethod(ParameterisedTestMethodRunner.java:40)
	at junitparams.internal.ParameterisedTestClassRunner.runParameterisedTest(ParameterisedTestClassRunner.java:146)
	at junitparams.JUnitParamsRunner.runChild(JUnitParamsRunner.java:446)
	at junitparams.JUnitParamsRunner.runChild(JUnitParamsRunner.java:393)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)
Caused by: org.apache.hadoop.fs.ChecksumException: Checksum error: file:/var/folders/q3/hw5cxmn52wq347lg7rb_mzlw0000gq/T/test1179670579977857255.vcf at 0
	at org.apache.hadoop.fs.ChecksumFileSystem$ChecksumFSInputChecker.readChunk(ChecksumFileSystem.java:260)
	at org.apache.hadoop.fs.FSInputChecker.readChecksumChunk(FSInputChecker.java:300)
	at org.apache.hadoop.fs.FSInputChecker.read1(FSInputChecker.java:252)
	at org.apache.hadoop.fs.FSInputChecker.read(FSInputChecker.java:197)
	at java.io.DataInputStream.read(DataInputStream.java:149)
	at org.disq_bio.disq.impl.file.HadoopFileSystemWrapper$SeekableHadoopStream.read(HadoopFileSystemWrapper.java:241)
	at java.io.BufferedInputStream.fill(BufferedInputStream.java:246)
	at java.io.BufferedInputStream.read1(BufferedInputStream.java:286)
	at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
	at htsjdk.samtools.seekablestream.SeekableBufferedStream.read(SeekableBufferedStream.java:133)
	at java.io.BufferedInputStream.fill(BufferedInputStream.java:246)
	at java.io.BufferedInputStream.read1(BufferedInputStream.java:286)
	at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
	at java.io.FilterInputStream.read(FilterInputStream.java:107)
	at htsjdk.tribble.readers.PositionalBufferedStream.fill(PositionalBufferedStream.java:132)
	at htsjdk.tribble.readers.PositionalBufferedStream.peek(PositionalBufferedStream.java:123)
	at htsjdk.tribble.readers.PositionalBufferedStream.read(PositionalBufferedStream.java:62)
	at htsjdk.tribble.readers.AsciiLineReader.readLine(AsciiLineReader.java:134)
	at htsjdk.tribble.readers.AsciiLineReader.readLine(AsciiLineReader.java:182)
	at htsjdk.tribble.readers.AsciiLineReaderIterator$TupleIterator.advance(AsciiLineReaderIterator.java:86)
	... 34 more
```
There may be other mechanisms to avoid this check.  A better solution would be to make the check pass but I'm not sure why it's failing in the first place.

Would you support dropping support for spark 2 and scala 11?  I'm in favor because it makes my life easier but I'm not sure what versions you need to support.  

This would close #130 

@tomwhite If you happen to have any insight into the checksum thing it might be valuable.  I believe we had a similar issue in the hadoop-bam days but it went away in disq.  