### PR TITLE
Fix format errors reported by fmt-maven-plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,10 @@ on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        distribution: [ 'zulu' ]
+        java: [ '8', '11' ]
     env:
         NO_GCE_CHECK: true
         SPARK_LOCAL_IP: localhost
@@ -13,8 +16,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          distribution: ${{ matrix.distribution }}
       - uses: actions/cache@v2
         with:
           path: ~/.m2

--- a/src/test/java/org/disq_bio/disq/AnySamTestUtil.java
+++ b/src/test/java/org/disq_bio/disq/AnySamTestUtil.java
@@ -56,8 +56,10 @@ import org.disq_bio.disq.impl.formats.sam.SamFormat;
 import org.junit.Assert;
 
 public class AnySamTestUtil {
-  // use a target contig size that corresponds to the size of the contig in the test.fa reference file used by the tests
+  // use a target contig size that corresponds to the size of the contig in the test.fa reference
+  // file used by the tests
   private static final int TARGET_CONTIG_SIZE = 47600;
+
   public static String writeAnySamFile(
       int numPairs,
       SAMFileHeader.SortOrder sortOrder,
@@ -66,14 +68,17 @@ public class AnySamTestUtil {
       throws IOException {
     SamFormat samFormat = SamFormat.fromFormatWriteOption(formatWriteOption);
     // file will be both queryname and coordinate sorted, so use one or the other
-    SAMRecordSetBuilder samRecordSetBuilder = new SAMRecordSetBuilder(true, sortOrder, true, TARGET_CONTIG_SIZE);
+    SAMRecordSetBuilder samRecordSetBuilder =
+        new SAMRecordSetBuilder(true, sortOrder, true, TARGET_CONTIG_SIZE);
     for (int i = 0; i < numPairs; i++) {
       int chr = 20;
       int start1 = (i + 1) * 40;
       int start2 = start1 + 100;
       if (start1 > TARGET_CONTIG_SIZE || start2 > TARGET_CONTIG_SIZE) {
-        // reads that are mapped outside of the target reference contig span can cause problems for CRAM files
-        throw new IllegalStateException(String.format("Read is mapped outside of the target span: %d", TARGET_CONTIG_SIZE));
+        // reads that are mapped outside of the target reference contig span can cause problems for
+        // CRAM files
+        throw new IllegalStateException(
+            String.format("Read is mapped outside of the target span: %d", TARGET_CONTIG_SIZE));
       }
       if (i == 5) { // add two unmapped fragments instead of a mapped pair
         samRecordSetBuilder.addFrag(

--- a/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
+++ b/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
@@ -444,12 +444,14 @@ public class HtsjdkReadsRddTest extends BaseTest {
         && SamtoolsTestUtil.isSamtoolsAvailable()
         && !formatWriteOption.equals(ReadsFormatWriteOption.SAM)) {
       if (ReadsFormatWriteOption.CRAM != formatWriteOption) {
-        // in some cases, samtools doesn't return correct counts for unmapped reads in a CRAM, so disable
-        // samtools cross-checking until we get a samtools fix. see https://github.com/disq-bio/disq/issues/163
+        // in some cases, samtools doesn't return correct counts for unmapped reads in a CRAM, so
+        // disable
+        // samtools cross-checking until we get a samtools fix. see
+        // https://github.com/disq-bio/disq/issues/163
         // and https://github.com/samtools/htslib/issues/1387
         if (ReadsFormatWriteOption.CRAM != formatWriteOption) {
           int expectedCountSamtools =
-                  SamtoolsTestUtil.countReads(inputPath, refPath, traversalParameters);
+              SamtoolsTestUtil.countReads(inputPath, refPath, traversalParameters);
           Assert.assertEquals(expectedCountSamtools, htsjdkReadsRdd.getReads().count());
         }
       }


### PR DESCRIPTION
Fixes for format errors reported by fmt-maven-plugin
```
[INFO] --- fmt-maven-plugin:2.9:check (default) @ disq ---
[INFO] Processed 91 files (2 non-complying).
[ERROR] Found 2 non-complying files, failing build
[ERROR] To fix formatting errors, run "mvn com.coveo:fmt-maven-plugin:format"
[ERROR] Non complying file: /Users/heuermh/working/disq/src/test/java/org/disq_bio/disq/AnySamTestUtil.java
[ERROR] Non complying file: /Users/heuermh/working/disq/src/test/java/org/disq_bio/disq/HtsjdkReadsRddTest.java
```
