### PR TITLE
Update to htsjdk 3.0, change Allele->SimpleAllele.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.source>${java.version}</maven.compiler.source>
-        <htsjdk.version>2.24.1</htsjdk.version>
+        <htsjdk.version>3.0.0</htsjdk.version>
         <hadoop.version>3.2.1</hadoop.version>
         <mockito.version>3.7.7</mockito.version>
         <kryo-serializers.version>0.43</kryo-serializers.version>

--- a/src/main/java/org/disq_bio/disq/serializer/DisqKryoRegistrator.java
+++ b/src/main/java/org/disq_bio/disq/serializer/DisqKryoRegistrator.java
@@ -115,7 +115,7 @@ public class DisqKryoRegistrator implements KryoRegistrator {
     kryo.register(htsjdk.samtools.util.Interval.class);
 
     // htsjdk.variant.variantcontext
-    kryo.register(htsjdk.variant.variantcontext.Allele.class);
+    kryo.register(htsjdk.variant.variantcontext.SimpleAllele.class);
     kryo.register(htsjdk.variant.variantcontext.CommonInfo.class);
     kryo.register(htsjdk.variant.variantcontext.FastGenotype.class);
     kryo.register(htsjdk.variant.variantcontext.GenotypeType.class);


### PR DESCRIPTION
Note that this change may have ramifications for downstream projects due to the change of the `Allele` class to an interface, with `SimpleAllele` as the concrete replacement.